### PR TITLE
export type of 'JsPlugin'

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from './compiler/index.js';
 export * from './config/index.js';
 export * from './server/index.js';
+export * from './plugin/index.js';
 
 import chalk from 'chalk';
 import { Compiler } from './compiler/index.js';


### PR DESCRIPTION
when I write a plugin like this
```js
export deafult function plugin(options):JsPlugin{
  return {}
}
```
we maybe need type of 'JsPlugin'