### PR TITLE
fix: js plugin cannot use custom type

### DIFF
--- a/.changeset/late-foxes-begin.md
+++ b/.changeset/late-foxes-begin.md
@@ -1,0 +1,5 @@
+---
+'@farmfe/core': patch
+---
+
+fix ModuleType serialization

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,6 +417,7 @@ dependencies = [
  "farmfe_utils",
  "glob",
  "hashbrown",
+ "heck",
  "hex",
  "parking_lot",
  "petgraph",
@@ -793,6 +794,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -32,3 +32,4 @@ swc_ecma_parser = { version = "0.130.2" }
 swc_common = { version = "0.29.37", features = ["concurrent", "sourcemap"] }
 swc_css_ast = { version = "0.134.11", features = ["rkyv-impl"] }
 swc_html_ast = { version = "0.28.30", features = ["rkyv-impl"] }
+heck = "0.4.1"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

js plugin cannot use custom type

```ts
return {
    content: data,
    moduleType: 'scss',
}
```

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

`None`

**Related issue (if exists):**

`None`