### PR TITLE
fix: bootstrap script build core package

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -34,10 +34,14 @@ export const installLinuxProtobuf = () =>
   });
 
 // build core command
-export const buildCore = () =>
+export const buildCore = () => {
   execa(DEFAULT_PACKAGE_MANAGER, ['build:rs'], {
     cwd: PKG_CORE,
   });
+  execa(DEFAULT_PACKAGE_MANAGER, ['build'], {
+    cwd: PKG_CORE,
+  });
+};
 
 // build rust plugins
 export const rustPlugins = () => batchBuildPlugins(PKG_RUST_PLUGIN);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Solve the problem that if core is not packaged, it will cause other package build errors.
