### PR TITLE
fix: pnpm-v8 depsversion error

### DIFF
--- a/js-plugins/vue/package.json
+++ b/js-plugins/vue/package.json
@@ -45,9 +45,9 @@
   },
   "peerDependencies": {
     "@farmfe/core": "^0.6.0",
-    "less": "*",
-    "sass": "*",
-    "stylus": "*"
+    "less": "latest",
+    "sass": "latest",
+    "stylus": "latest"
   },
   "peerDependenciesMeta": {
     "less": {

--- a/packages/cli/templates/react/package.json
+++ b/packages/cli/templates/react/package.json
@@ -7,9 +7,9 @@
     "react-dom": "18"
   },
   "devDependencies": {
-    "@farmfe/cli": "*",
-    "@farmfe/core": "*",
-    "@farmfe/plugin-react": "*",
+    "@farmfe/cli": "latest",
+    "@farmfe/core": "latest",
+    "@farmfe/plugin-react": "latest",
     "@types/react": "18",
     "@types/react-dom": "18",
     "react-refresh": "^0.14.0"

--- a/packages/cli/templates/rust-plugin/package.json
+++ b/packages/cli/templates/rust-plugin/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "MIT",
   "devDependencies": {
-    "@farmfe/cli": "*"
+    "@farmfe/cli": "latest"
   },
   "exports": {
     ".": {

--- a/packages/cli/templates/vue/package.json
+++ b/packages/cli/templates/vue/package.json
@@ -6,9 +6,9 @@
     "vue": "^3.2.45"
   },
   "devDependencies": {
-    "@farmfe/cli": "*",
-    "@farmfe/core": "*",
-    "@farmfe/js-plugin-vue": "*"
+    "@farmfe/cli": "latest",
+    "@farmfe/core": "latest",
+    "@farmfe/js-plugin-vue": "latest"
   },
   "scripts": {
     "start": "farm start",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,16 +201,16 @@ importers:
         specifier: ^3.2.47
         version: 3.2.47
       less:
-        specifier: '*'
+        specifier: latest
         version: 4.1.3
       sass:
-        specifier: '*'
-        version: 1.60.0
+        specifier: latest
+        version: 1.62.0
       source-map:
         specifier: ^0.7.4
         version: 0.7.4
       stylus:
-        specifier: '*'
+        specifier: latest
         version: 0.59.0
     devDependencies:
       '@farmfe/core':
@@ -378,7 +378,7 @@ importers:
   rust-plugins/react:
     devDependencies:
       '@farmfe/cli':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../../packages/cli
       '@napi-rs/cli':
         specifier: ^2.10.0
@@ -409,7 +409,7 @@ importers:
         version: 1.60.0
     devDependencies:
       '@farmfe/cli':
-        specifier: '*'
+        specifier: workspace:*
         version: link:../../packages/cli
       '@napi-rs/cli':
         specifier: ^2.10.0
@@ -6565,6 +6565,16 @@ packages:
       chokidar: 3.5.3
       immutable: 4.3.0
       source-map-js: 1.0.2
+
+  /sass@1.62.0:
+    resolution: {integrity: sha512-Q4USplo4pLYgCi+XlipZCWUQz5pkg/ruSSgJ0WRDSb/+3z9tXUOkQ7QPYn4XrhZKYAK4HlpaQecRwKLJX6+DBg==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+    dependencies:
+      chokidar: 3.5.3
+      immutable: 4.3.0
+      source-map-js: 1.0.2
+    dev: false
 
   /sax@1.2.4:
     resolution: {integrity: sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==}

--- a/rust-plugins/react/package.json
+++ b/rust-plugins/react/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "license": "MIT",
   "devDependencies": {
-    "@farmfe/cli": "*",
+    "@farmfe/cli": "workspace:*",
     "@napi-rs/cli": "^2.10.0"
   },
   "napi": {

--- a/rust-plugins/sass/package.json
+++ b/rust-plugins/sass/package.json
@@ -9,7 +9,7 @@
     "node": ">=16"
   },
   "devDependencies": {
-    "@farmfe/cli": "*",
+    "@farmfe/cli": "workspace:*",
     "@napi-rs/cli": "^2.10.0",
     "extract-zip": "^2.0.1",
     "node-fetch": "^3.2.10",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Use pnpm8 to prevent the use of `*` to cause version number inconsistency



