### PR TITLE
fix: prefer string type over String

### DIFF
--- a/packages/core/binding/index.d.ts
+++ b/packages/core/binding/index.d.ts
@@ -38,7 +38,7 @@ export interface PluginResolveHookParam {
 
 export interface PluginResolveHookResult {
   /// resolved path, normally a absolute path. you can also return a virtual path, and use [PluginLoadHookResult] to provide the content of the virtual path
-  resolvedPath: String;
+  resolvedPath: string;
   /// whether this module should be external, if true, the module won't present in the final result
   external: boolean;
   /// whether this module has side effects, affects tree shaking
@@ -81,7 +81,7 @@ export interface PluginTransformHookResult {
   /// you can change the module type after transform.
   moduleType?: ModuleType;
   /// transformed source map, all plugins' transformed source map will be stored as a source map chain.
-  sourceMap?: String | null;
+  sourceMap?: string | null;
 }
 
 export interface Config {


### PR DESCRIPTION
**Description:**

Per [TS docs](https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#number-string-boolean-symbol-and-object): 

> Don’t ever use the types Number, String, Boolean, Symbol, or Object These types refer to non-primitive boxed objects that are almost never used appropriately in JavaScript code.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
