### PR TITLE
feat: disable HMR in prod builds

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -27,6 +27,8 @@ export const DEFAULT_CONFIG_NAMES = [
   "farm.config.mjs",
 ];
 
+type CompilationMode = "development" | "production";
+
 /**
  * Normalize user config and transform it to rust compiler compatible config
  * @param config
@@ -34,7 +36,7 @@ export const DEFAULT_CONFIG_NAMES = [
  */
 export async function normalizeUserCompilationConfig(
   userConfig: UserConfig,
-  mode: "development" | "production" = "production"
+  mode: CompilationMode = "production"
 ): Promise<Config> {
   const config: Config["config"] = merge(
     {
@@ -97,7 +99,8 @@ export async function normalizeUserCompilationConfig(
   }
 
   const normalizedDevServerConfig = normalizeDevServerOptions(
-    userConfig.server
+    userConfig.server,
+    mode
   );
 
   if (
@@ -174,17 +177,17 @@ export const DEFAULT_DEV_SERVER_OPTIONS: NormalizedServerConfig = {
 };
 
 export function normalizeDevServerOptions(
-  options?: UserServerConfig
+  options: UserServerConfig | undefined,
+  mode: CompilationMode
 ): NormalizedServerConfig {
-  if (!options) {
-    return DEFAULT_DEV_SERVER_OPTIONS;
-  }
-
-  if (options.hmr === true) {
-    options.hmr = DEFAULT_HMR_OPTIONS;
-  }
-
-  return merge({}, DEFAULT_DEV_SERVER_OPTIONS, options);
+  return merge({}, DEFAULT_DEV_SERVER_OPTIONS, options, {
+    hmr:
+      mode === "production"
+        ? false
+        : options?.hmr !== false
+        ? DEFAULT_HMR_OPTIONS
+        : options.hmr,
+  });
 }
 
 /**

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -40,7 +40,7 @@ export class DevServer {
     public logger: Logger,
     options?: UserServerConfig
   ) {
-    this.config = normalizeDevServerOptions(options);
+    this.config = normalizeDevServerOptions(options, "development");
     this._app = new Koa();
 
     // this._app.use(serve(this._dist));

--- a/packages/core/tests/config.spec.ts
+++ b/packages/core/tests/config.spec.ts
@@ -30,14 +30,24 @@ test("resolveUserConfig", async () => {
   });
 });
 
-test("normalize-dev-server-options", () => {
-  let options = normalizeDevServerOptions({});
-  expect(options.https).toBe(DEFAULT_DEV_SERVER_OPTIONS.https);
-  expect(options.port).toBe(DEFAULT_DEV_SERVER_OPTIONS.port);
+describe("normalize-dev-server-options", () => {
+  test("default", () => {
+    const options = normalizeDevServerOptions({}, "development");
+    expect(options.https).toBe(DEFAULT_DEV_SERVER_OPTIONS.https);
+    expect(options.port).toBe(DEFAULT_DEV_SERVER_OPTIONS.port);
+    expect(options.hmr).not.toBe(false);
+  });
 
-  options = normalizeDevServerOptions({ port: 8080 });
-  expect(options.https).toBe(DEFAULT_DEV_SERVER_OPTIONS.https);
-  expect(options.port).toBe(8080);
+  test("custom port", () => {
+    const options = normalizeDevServerOptions({ port: 8080 }, "development");
+    expect(options.https).toBe(DEFAULT_DEV_SERVER_OPTIONS.https);
+    expect(options.port).toBe(8080);
+  });
+
+  test("disable HMR in prod", () => {
+    const options = normalizeDevServerOptions({}, "production");
+    expect(options.hmr).toBe(false);
+  });
 });
 
 describe("parseUserConfig", () => {


### PR DESCRIPTION
**Description:**

This PR forces `server.hmr` option to false for production builds as there is no dev server in those cases anyways. 

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
Closes #249