### PR TITLE
fix: sfc filename in @farmfe/js-plugin-vue

### DIFF
--- a/js-plugins/vue/src/generatorCode.ts
+++ b/js-plugins/vue/src/generatorCode.ts
@@ -238,11 +238,12 @@ export function genOtherCode(
   hasScoped: boolean,
   hash: string,
   isHmr = false,
-  rerenderOnly: boolean
+  rerenderOnly: boolean,
+  filename: string
 ) {
   const otherCodeArr = [
     assignRenderCode,
-    assignFilenameCode,
+    genFileNameCode(filename),
     hasScoped ? genAssignScopedCode(hash) : '',
     genAssignHmrIdCode(hash),
     defaultHmrCode,
@@ -316,7 +317,7 @@ export function genMainCode(
     deleteStyles,
     addStyles
   );
-  const otherCode = genOtherCode(hasScoped, hash, isHmr, rerenderOnly);
+  const otherCode = genOtherCode(hasScoped, hash, isHmr, rerenderOnly, filename);
 
   output.push(scriptCode, templateCode, stylesCode, otherCode);
   return {


### PR DESCRIPTION
**Description:**

A fixed filename is used to generate sfc code, causes same filename in vnode and same component name in Devtools.

**BREAKING CHANGE:**

**Related issue (if exists):**