### PR TITLE
fix: styles import in Vue SFC

### DIFF
--- a/.changeset/swift-steaks-cheer.md
+++ b/.changeset/swift-steaks-cheer.md
@@ -1,0 +1,5 @@
+---
+'@farmfe/js-plugin-vue': patch
+---
+
+fix: styles import in Vue SFC

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ target
 
 build
 .swc
+.DS_Store

--- a/examples/vue/package.json
+++ b/examples/vue/package.json
@@ -10,7 +10,8 @@
   "devDependencies": {
     "@farmfe/cli": "workspace:*",
     "@farmfe/core": "workspace:*",
-    "@farmfe/js-plugin-vue": "workspace:*"
+    "@farmfe/js-plugin-vue": "workspace:*",
+    "sass": "^1.62.1"
   },
   "scripts": {
     "start": "farm start",

--- a/examples/vue/src/Main.vue
+++ b/examples/vue/src/Main.vue
@@ -4,19 +4,21 @@
 
 <script lang="ts" setup>
 import Welcome from './components/Welcome.vue';
-import axios from "axios"
+import axios from 'axios';
 console.log(axios.create);
 fetch('/api')
   .then((response) => response.json())
   .then((json) => console.log(json));
 </script>
 
-<style>
+<style lang="scss">
+@import './styles/global.scss';
+
 #app {
   font-size: 18px;
   display: flex;
   justify-content: center;
-  max-width: 1280px;
+  max-width: $max-width;
   margin: 0 auto;
   font-weight: normal;
 }

--- a/examples/vue/src/styles/global.scss
+++ b/examples/vue/src/styles/global.scss
@@ -1,0 +1,1 @@
+$max-width: 1280px;

--- a/js-plugins/vue/package.json
+++ b/js-plugins/vue/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.5",
   "description": "support vue sfc for farm.",
   "main": "./build/index.cjs",
+  "module": "./dist/farm-vue-plugin.js",
   "types": "./dist/farm-vue-plugin.d.ts",
   "type": "module",
   "scripts": {
@@ -17,8 +18,10 @@
   ],
   "exports": {
     ".": {
-      "import": "./build/index.cjs",
-      "require": "./build/index.cjs"
+      "default": "./build/index.cjs",
+      "require": "./build/index.cjs",
+      "import": "./dist/farm-vue-plugin.js",
+      "types": "./dist/farm-vue-plugin.d.ts"
     }
   },
   "repository": {

--- a/js-plugins/vue/src/farm-vue-plugin.ts
+++ b/js-plugins/vue/src/farm-vue-plugin.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import { parse } from '@vue/compiler-sfc';
 import { JsPlugin, UserConfig } from '@farmfe/core';
 import { handleHmr } from './farm-vue-hmr.js';
@@ -70,7 +71,9 @@ export default function farmVuePlugin(
           const cssCode = stylesCodeCache[hash];
           // if lang is not "css", use preProcessor to handle
           if (applyStyleLangs.includes(lang)) {
-            const { css } = await preProcession(cssCode, lang);
+            const { css } = await preProcession(cssCode, lang, {
+              paths: [path.dirname(resolvedPath)]
+            });
 
             const { code: styleCode, errors } = compileStyle({
               source: css,
@@ -105,7 +108,7 @@ export default function farmVuePlugin(
           error({
             id: resolvedPath,
             message:
-              "path is not right,can't readFile" +
+              "path is not right, can't readFile" +
               JSON.stringify(ctx) +
               JSON.stringify(hookContext)
           });
@@ -116,7 +119,7 @@ export default function farmVuePlugin(
         };
       }
     },
-    // add hmr code In root file
+    // add hmr code in root file
     transform: {
       filters: {
         moduleTypes: ['vue']
@@ -194,7 +197,11 @@ export default function farmVuePlugin(
   };
 }
 
-async function preProcession(styleCode: string, moduleType: string) {
+async function preProcession(
+  styleCode: string,
+  moduleType: string,
+  options?: { paths: string[] }
+) {
   const __default = { css: styleCode, map: '' };
   let processor: ValueOf<PreProcessors>;
   try {
@@ -203,16 +210,21 @@ async function preProcession(styleCode: string, moduleType: string) {
     switch (moduleType) {
       case 'less':
         processor = await loadPreProcessor(PreProcessorsType.less);
-        return await compilePreProcessorCodeToCss(styleCode, processor);
+        return await compilePreProcessorCodeToCss(styleCode, processor, {
+          paths: options.paths ?? []
+        });
       case 'sass':
       case 'scss':
         processor = await loadPreProcessor(PreProcessorsType.sass);
         return await compilePreProcessorCodeToCss(styleCode, processor, {
-          indentedSyntax: moduleType === 'sass'
+          indentedSyntax: moduleType === 'sass',
+          includePaths: options.paths ?? []
         });
       case 'stylus':
         processor = await loadPreProcessor(PreProcessorsType.stylus);
-        return await compilePreProcessorCodeToCss(styleCode, processor);
+        return await compilePreProcessorCodeToCss(styleCode, processor, {
+          paths: options.paths ?? []
+        });
       default:
         return __default;
     }
@@ -231,13 +243,17 @@ export async function compilePreProcessorCodeToCss<
 ): Promise<{ css: string }> {
   if (isLess(preProcessor)) {
     return await new Promise((resolve, reject) => {
-      preProcessor.render(styleCode, {}, (error, { css }) => {
-        if (error) {
-          reject(error);
-        }
+      preProcessor.render(
+        styleCode,
+        options as Less.Options,
+        (error, { css }) => {
+          if (error) {
+            reject(error);
+          }
 
-        resolve({ css });
-      });
+          resolve({ css });
+        }
+      );
     });
   }
 
@@ -263,7 +279,7 @@ export async function compilePreProcessorCodeToCss<
 
   if (isStyl(preProcessor)) {
     return await new Promise((resolve, reject) => {
-      preProcessor.render(styleCode, {}, (err, css) => {
+      preProcessor.render(styleCode, options, (err, css) => {
         if (err) {
           reject(err);
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -416,6 +416,9 @@ importers:
       '@farmfe/js-plugin-vue':
         specifier: workspace:*
         version: link:../../js-plugins/vue
+      sass:
+        specifier: ^1.62.1
+        version: 1.62.1
 
   examples/vue-antdv:
     dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fix `@import` syntax in Vue SFC, without fixing, import style should based on root dir

```md
.
├── assets
│   ├── feature.svg
│   ├── light.svg
│   ├── logo.png
│   └── plugin.svg
├── src
│   ├── components
│   │   ├── Button.vue
│   │   ├── Card.vue
│   │   └── Welcome.vue
│   ├── styles
│   │   └── global.scss
│   ├── Main.vue
│   ├── base.css
│   ├── env.d.ts
│   └── index.ts
├── CHANGELOG.md
├── farm.config.ts
├── index.html
├── package.json
└── tsconfig.json
```

Before:
```vue
<script>
// src/Main.vue
</script>

<style lang="less">
// relative path is based on root dir
@import './src/styles/globals.less';
</style>
```

After:
```vue
<script>
// src/Main.vue
</script>

<style lang="less">
// relative path is based on current file dir
@import './styles/globals.less';
</style>
```
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

None
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**

None
