### PR TITLE
feat: Use grass as the replacement of dart-sass in rust plugin sass

### DIFF
--- a/.changeset/modern-pillows-look.md
+++ b/.changeset/modern-pillows-look.md
@@ -1,0 +1,5 @@
+---
+'@farmfe/plugin-sass': major
+---
+
+use grass as the replacement of dart-sass in rust plugin sass

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "any_ascii"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,6 +547,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim",
+ "textwrap 0.11.0",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "clipboard-win"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +571,12 @@ dependencies = [
  "str-buf",
  "winapi",
 ]
+
+[[package]]
+name = "codemap"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e769b5c8c8283982a987c6e948e540254f1058d5a74b8794914d4ef5fc2a24"
 
 [[package]]
 name = "codespan-reporting"
@@ -711,7 +741,7 @@ checksum = "624b54323b06e675293939311943ba82d323bb340468ce1889be5da7932c8d73"
 dependencies = [
  "cranelift-entity",
  "fxhash",
- "hashbrown",
+ "hashbrown 0.12.3",
  "indexmap",
  "log",
  "smallvec",
@@ -914,7 +944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
@@ -1255,7 +1285,7 @@ dependencies = [
  "farmfe_macro_cache_item",
  "farmfe_utils",
  "glob",
- "hashbrown",
+ "hashbrown 0.12.3",
  "heck 0.4.1",
  "hex",
  "parking_lot",
@@ -1422,6 +1452,7 @@ dependencies = [
  "farmfe_testing_helpers",
  "farmfe_toolkit",
  "farmfe_toolkit_plugin_types",
+ "grass",
  "sass-embedded",
  "serde",
 ]
@@ -1870,6 +1901,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "grass"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cc4b64880a2264a41f9eab431780e72a68a6c88b9bddef361ba638812d572e"
+dependencies = [
+ "clap",
+ "grass_compiler",
+]
+
+[[package]]
+name = "grass_compiler"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e4feeef87d958eebd4d55431040768b93a5b088202198e0b203adc3c1d468c6"
+dependencies = [
+ "codemap",
+ "indexmap",
+ "lasso",
+ "once_cell",
+ "phf",
+ "rand",
+]
+
+[[package]]
 name = "half"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1882,6 +1937,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+dependencies = [
+ "ahash 0.7.6",
 ]
 
 [[package]]
@@ -2021,7 +2085,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
 ]
 
@@ -2149,6 +2213,15 @@ name = "khronos_api"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "lasso"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb7b21a526375c5ca55f1a6dfd4e1fad9fa4edd750f530252a718a44b2608f0"
+dependencies = [
+ "hashbrown 0.11.2",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2315,7 +2388,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -2384,7 +2457,7 @@ dependencies = [
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
- "textwrap",
+ "textwrap 0.15.2",
  "thiserror",
  "unicode-width",
 ]
@@ -3306,7 +3379,7 @@ checksum = "0200c8230b013893c0b2d6213d6ec64ed2b9be2e0e016682b7224ff82cff5c58"
 dependencies = [
  "bitvec",
  "bytecheck 0.6.11",
- "hashbrown",
+ "hashbrown 0.12.3",
  "indexmap",
  "ptr_meta",
  "rend",
@@ -3923,6 +3996,12 @@ dependencies = [
  "swc_macros_common",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "subtle"
@@ -4920,6 +4999,15 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
+name = "textwrap"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
@@ -5222,7 +5310,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c5faade31a542b8b35855fff6e8def199853b2da8da256da52f52f1316ee3137"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
  "regex",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,27 +1216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "error-code"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,7 +1432,6 @@ dependencies = [
  "farmfe_toolkit",
  "farmfe_toolkit_plugin_types",
  "grass",
- "sass-embedded",
  "serde",
 ]
 
@@ -1546,15 +1524,6 @@ name = "farmfe_utils"
 version = "0.0.1"
 dependencies = [
  "pathdiff",
-]
-
-[[package]]
-name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
 ]
 
 [[package]]
@@ -2004,12 +1973,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,17 +2084,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
-dependencies = [
- "hermit-abi 0.3.1",
- "libc",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2358,12 +2310,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b085a4f2cde5781fc4b1717f2e86c62f5cda49de7ba99a7c2eae02b61c9064c"
-
-[[package]]
 name = "lock_api"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,12 +2461,6 @@ name = "more-asserts"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
-
-[[package]]
-name = "multimap"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "napi"
@@ -3022,16 +2962,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.1.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
-dependencies = [
- "proc-macro2",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,60 +3008,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
-dependencies = [
- "bytes",
- "heck 0.4.1",
- "itertools",
- "lazy_static",
- "log",
- "multimap",
- "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
- "regex",
- "syn 1.0.109",
- "tempfile",
- "which",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "prost-types"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
-dependencies = [
- "prost",
 ]
 
 [[package]]
@@ -3487,20 +3363,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.37.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79bef90eb6d984c72722595b5b1348ab39275a5e5123faca6863bf07d75a4e0"
-dependencies = [
- "bitflags 1.3.2",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "ruzstd"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3530,26 +3392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "sass-embedded"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91bc40eea43391e185d1760f78b7d254f8f8348da7ff7963e98c10ecd1ed0f15"
-dependencies = [
- "atty",
- "crossbeam-channel",
- "dashmap",
- "parking_lot",
- "prost",
- "prost-build",
- "regex",
- "rustc-hash",
- "serde",
- "serde_json",
- "url",
- "urlencoding",
 ]
 
 [[package]]
@@ -4947,19 +4789,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd1ba337640d60c3e96bc6f0638a939b9c9a7f2c316a1598c279828b3d1dc8c5"
 
 [[package]]
-name = "tempfile"
-version = "3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9fbec84f381d5795b08656e4912bec604d162bff9291d6189a78f4c8ab87998"
-dependencies = [
- "cfg-if",
- "fastrand",
- "redox_syscall 0.3.5",
- "rustix",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "term_size"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6031,17 +5860,6 @@ name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
-
-[[package]]
-name = "which"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
-dependencies = [
- "either",
- "libc",
- "once_cell",
-]
 
 [[package]]
 name = "winapi"

--- a/rust-plugins/sass/Cargo.toml
+++ b/rust-plugins/sass/Cargo.toml
@@ -11,7 +11,6 @@ farmfe_core = { version = "*", path = "../../crates/core" }
 farmfe_macro_plugin = { version = "*", path = "../../crates/macro_plugin" }
 farmfe_toolkit_plugin_types = { version = "*", path = "../../crates/toolkit_plugin_types" }
 farmfe_toolkit = { path = "../../crates/toolkit" }
-sass-embedded = { version = "0.6.2", features = ["legacy", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
 grass = { version = "0.12.4"}
 

--- a/rust-plugins/sass/Cargo.toml
+++ b/rust-plugins/sass/Cargo.toml
@@ -13,6 +13,7 @@ farmfe_toolkit_plugin_types = { version = "*", path = "../../crates/toolkit_plug
 farmfe_toolkit = { path = "../../crates/toolkit" }
 sass-embedded = { version = "0.6.2", features = ["legacy", "serde"] }
 serde = { version = "1.0", features = ["derive"] }
+grass = { version = "0.12.4"}
 
 [dev-dependencies]
 farmfe_testing_helpers = { path = "../../crates/testing_helpers" }

--- a/rust-plugins/sass/src/lib.rs
+++ b/rust-plugins/sass/src/lib.rs
@@ -4,7 +4,6 @@ use farmfe_core::{config::Config, module::ModuleType, plugin::Plugin};
 use farmfe_macro_plugin::farm_plugin;
 use farmfe_toolkit::{fs, regex::Regex};
 use serde::{Deserialize, Serialize};
-use grass;
 
 #[farm_plugin]
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -55,7 +54,7 @@ impl Plugin for FarmPluginSass {
   ) -> farmfe_core::error::Result<Option<farmfe_core::plugin::PluginTransformHookResult>> {
     if param.module_type == ModuleType::Custom(String::from("sass")) {
       let css = grass::from_string(
-        &param.content.to_owned(),
+        param.content.to_owned(),
         &grass::Options::default())
         .map_err(|e| farmfe_core::error::CompilationError::TransformError {
           resolved_path: param.resolved_path.to_string(),

--- a/rust-plugins/sass/src/lib.rs
+++ b/rust-plugins/sass/src/lib.rs
@@ -1,18 +1,10 @@
 #![deny(clippy::all)]
 
-use farmfe_core::relative_path::RelativePath;
-use farmfe_core::serde_json::{self, Value};
 use farmfe_core::{config::Config, module::ModuleType, plugin::Plugin};
 use farmfe_macro_plugin::farm_plugin;
-use farmfe_toolkit::{fs, regex::Regex, resolve::follow_symlinks};
-use sass_embedded::{OutputStyle, Sass, StringOptions, StringOptionsBuilder, Url};
+use farmfe_toolkit::{fs, regex::Regex};
 use serde::{Deserialize, Serialize};
-use std::env;
-use std::env::consts::{ARCH, OS};
-use std::path::PathBuf;
 use grass;
-
-const PKG_NAME: &str = "@farmfe/plugin-sass";
 
 #[farm_plugin]
 #[derive(Debug, Deserialize, Serialize, Default)]
@@ -27,11 +19,11 @@ impl FarmPluginSass {
       sass_options: options,
     }
   }
-
-  pub fn get_sass_options(&self, resolve_path: String) -> StringOptions {
-    let options = serde_json::from_str(&self.sass_options).unwrap_or_default();
-    get_options(options, resolve_path)
-  }
+  
+  // TODO support options
+  // pub fn get_sass_options(&self, resolve_path: String) -> grass::Options {
+  //   let options = serde_json::from_str(&self.sass_options).unwrap_or_default();
+  // }
 }
 
 impl Plugin for FarmPluginSass {
@@ -62,26 +54,10 @@ impl Plugin for FarmPluginSass {
     _context: &std::sync::Arc<farmfe_core::context::CompilationContext>,
   ) -> farmfe_core::error::Result<Option<farmfe_core::plugin::PluginTransformHookResult>> {
     if param.module_type == ModuleType::Custom(String::from("sass")) {
-      // let exe_path: PathBuf = get_exe_path();
-      // let mut sass = Sass::new(exe_path).unwrap_or_else(|e| {
-      //   panic!(
-      //     "\n sass-embedded init error: {},\n Please try to install manually. eg: \n pnpm install sass-embedded-{}-{} \n",
-      //     e.message(),
-      //     get_os(),
-      //     get_arch()
-      //   )
-      // });
-      // let string_options = self.get_sass_options(param.resolved_path.to_string());
-      // let compile_result = sass
-      //   .compile_string(&param.content, string_options)
-      //   .map_err(|e| farmfe_core::error::CompilationError::TransformError {
-      //     resolved_path: param.resolved_path.to_string(),
-      //     msg: e.message().to_string(),
-      //   })?;
-      
       let css = grass::from_string(
         &param.content.to_owned(),
-        &grass::Options::default()).map_err(|e| farmfe_core::error::CompilationError::TransformError {
+        &grass::Options::default())
+        .map_err(|e| farmfe_core::error::CompilationError::TransformError {
           resolved_path: param.resolved_path.to_string(),
           msg: e.to_string(),
         })?;
@@ -95,104 +71,6 @@ impl Plugin for FarmPluginSass {
   }
 }
 
-fn get_os() -> &'static str {
-  match OS {
-    "linux" => "linux",
-    "macos" => "darwin",
-    "windows" => "win32",
-    os => panic!("dart-sass-embed is not supported OS: {}", os),
-  }
-}
 
-fn get_arch() -> &'static str {
-  match ARCH {
-    "x86" => "ia32",
-    "x86_64" => "x64",
-    "aarch64" => "arm64",
-    arch => panic!("dart-sass-embed is not supported arch: {}", arch),
-  }
-}
 
-fn get_exe_path() -> PathBuf {
-  let os = get_os();
-  let arch = get_arch();
-  let entry_file = if let "win32" = os {
-    "dart-sass-embedded.bat"
-  } else {
-    "dart-sass-embedded"
-  };
 
-  let cur_dir = env::current_dir().unwrap();
-
-  // user manually installs related dependencies
-  let manual_installation_path = RelativePath::new(&format!(
-    "node_modules/sass-embedded-{os}-{arch}/dart-sass-embedded/{entry_file}"
-  ))
-  .to_logical_path(&cur_dir);
-
-  let pkg_dir = follow_symlinks(
-    RelativePath::new("node_modules")
-      .join(PKG_NAME)
-      .to_logical_path(&cur_dir),
-  );
-
-  // find closest node_modules start from pkg_dir
-  let mut cur_dir = pkg_dir;
-
-  while !cur_dir.join("node_modules").exists() {
-    if cur_dir.parent().is_none() {
-      panic!("can not find node_modules in @farmfe/plugin-sass");
-    }
-
-    cur_dir = cur_dir.parent().unwrap().to_path_buf();
-  }
-
-  let default_path = RelativePath::new("node_modules")
-    .join(format!("sass-embedded-{os}-{arch}"))
-    .join(format!("dart-sass-embedded/{entry_file}"))
-    .to_logical_path(&cur_dir);
-
-  if manual_installation_path.exists() {
-    manual_installation_path
-  } else {
-    default_path
-  }
-}
-
-fn get_options(options: Value, resolve_path: String) -> StringOptions {
-  let mut builder = StringOptionsBuilder::new();
-  builder = builder.url(Url::from_file_path(resolve_path).unwrap());
-  if let Some(source_map) = options.get("sourceMap") {
-    builder = builder.source_map(source_map.as_bool().unwrap());
-  }
-  if let Some(source_map_include_sources) = options.get("sourceMapIncludeSources") {
-    builder = builder.source_map(source_map_include_sources.as_bool().unwrap());
-  }
-  if let Some(alert_ascii) = options.get("alertAscii") {
-    builder = builder.alert_ascii(alert_ascii.as_bool().unwrap());
-  }
-  if let Some(alert_color) = options.get("alertColor") {
-    builder = builder.alert_color(alert_color.as_bool().unwrap())
-  }
-  if let Some(charset) = options.get("charset") {
-    builder = builder.charset(charset.as_bool().unwrap());
-  }
-  if let Some(quiet_deps) = options.get("quietDeps") {
-    builder = builder.quiet_deps(quiet_deps.as_bool().unwrap());
-  }
-  if let Some(verbose) = options.get("verbose") {
-    builder = builder.verbose(verbose.as_bool().unwrap());
-  }
-  if let Some(style) = options.get("style") {
-    let output_style = match style.as_str().unwrap() {
-      "expanded" => OutputStyle::Expanded,
-      "compressed" => OutputStyle::Compressed,
-      _ => panic!("sass stringOptions does not support this style configuration"),
-    };
-    builder = builder.style(output_style);
-  }
-
-  // TODO support more options
-
-  builder.build()
-}

--- a/rust-plugins/sass/src/lib.rs
+++ b/rust-plugins/sass/src/lib.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use std::env;
 use std::env::consts::{ARCH, OS};
 use std::path::PathBuf;
+use grass;
 
 const PKG_NAME: &str = "@farmfe/plugin-sass";
 
@@ -61,24 +62,31 @@ impl Plugin for FarmPluginSass {
     _context: &std::sync::Arc<farmfe_core::context::CompilationContext>,
   ) -> farmfe_core::error::Result<Option<farmfe_core::plugin::PluginTransformHookResult>> {
     if param.module_type == ModuleType::Custom(String::from("sass")) {
-      let exe_path: PathBuf = get_exe_path();
-      let mut sass = Sass::new(exe_path).unwrap_or_else(|e| {
-        panic!(
-          "\n sass-embedded init error: {},\n Please try to install manually. eg: \n pnpm install sass-embedded-{}-{} \n",
-          e.message(),
-          get_os(),
-          get_arch()
-        )
-      });
-      let string_options = self.get_sass_options(param.resolved_path.to_string());
-      let compile_result = sass
-        .compile_string(&param.content, string_options)
-        .map_err(|e| farmfe_core::error::CompilationError::TransformError {
+      // let exe_path: PathBuf = get_exe_path();
+      // let mut sass = Sass::new(exe_path).unwrap_or_else(|e| {
+      //   panic!(
+      //     "\n sass-embedded init error: {},\n Please try to install manually. eg: \n pnpm install sass-embedded-{}-{} \n",
+      //     e.message(),
+      //     get_os(),
+      //     get_arch()
+      //   )
+      // });
+      // let string_options = self.get_sass_options(param.resolved_path.to_string());
+      // let compile_result = sass
+      //   .compile_string(&param.content, string_options)
+      //   .map_err(|e| farmfe_core::error::CompilationError::TransformError {
+      //     resolved_path: param.resolved_path.to_string(),
+      //     msg: e.message().to_string(),
+      //   })?;
+      
+      let css = grass::from_string(
+        &param.content.to_owned(),
+        &grass::Options::default()).map_err(|e| farmfe_core::error::CompilationError::TransformError {
           resolved_path: param.resolved_path.to_string(),
-          msg: e.message().to_string(),
+          msg: e.to_string(),
         })?;
       return Ok(Some(farmfe_core::plugin::PluginTransformHookResult {
-        content: compile_result.css,
+        content: css,
         source_map: None,
         module_type: Some(farmfe_core::module::ModuleType::Css),
       }));

--- a/rust-plugins/sass/tests/mod.rs
+++ b/rust-plugins/sass/tests/mod.rs
@@ -44,7 +44,7 @@ fn test() {
       .unwrap()
       .unwrap();
     let expected =
-      "body {\n  color: #000;\n}\nbody .description:hover {\n  background-color: #f8f9fa;\n}";
+      "body {\n  color: #000;\n}\nbody .description:hover {\n  background-color: #f8f9fa;\n}\n";
     assert_eq!(transformed.content, expected);
   });
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
Use grass as the replacement of dart-sass in rust plugin sass, delete sass embedded related codes
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
plugin option is currently not supported

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
close https://github.com/farm-fe/farm/issues/278
