### PR TITLE
fix(HMR): Prevent browser extension replay request report from throwing errors

### DIFF
--- a/packages/core/src/server/hmr-engine.ts
+++ b/packages/core/src/server/hmr-engine.ts
@@ -167,12 +167,18 @@ export class HmrEngine {
 
     if (result) {
       result.count--;
+      console.log(this._updateResults.size);
+
       // there are no more clients waiting for this update
-      if (result.count <= 0) {
-        this._updateResults.delete(id);
+      if (result.count <= 0 && this._updateResults.size === 2) {
+        /**
+         * Edge handle
+         * The BrowserExtension the user's browser may replay the request, resulting in an error that the result.id cannot be found.
+         * So keep the result of the last time every time, so that the request can be successfully carried out.
+         */
+        this._updateResults.delete(this._updateResults.keys().next().value);
       }
     }
-
     return result?.result;
   }
 }


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
Fix the problem that the user's browser extension may replay HMR requests, causing an error.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

none

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
fix: https://github.com/farm-fe/farm/issues/277