### PR TITLE
Fix/clean script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "start": "pnpm --filter @farmfe/cli start",
     "build": "pnpm --filter @farmfe/cli build",
     "release": "node scripts/release.mjs",
-    "clean": "rimraf node_modules **/*/node_modules && pnpm -r exec --parallel run clean",
+    "clean": "pnpm -r --filter='./packages/*' --filter='./js-plugins/*' run clean && rimraf node_modules",
     "bump": "node scripts/bump.mjs",
     "test:rs:update": "cross-env FARM_UPDATE_SNAPSHOTS=1 cargo test -p farmfe_compiler"
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
There are two deficiencies in the original instruction:
1. When node_modules is cleared, the rimraf command will not exist
2. The execution of pnpm exec requires that each sub-warehouse must have a corresponding command (but most sub-warehouses do not need clean commands such as runtime, runtime-plugin-hmr, etc.)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
None
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
None