### PR TITLE
feat(WIP): dev server ws port conflict and injection

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,7 +37,7 @@ export async function start(
   const config: UserConfig = await resolveUserConfig(inlineConfig, logger);
 
   const normalizedConfig = await normalizeUserCompilationConfig(config);
-
+  // TODO conflict_port
   const compiler = new Compiler(normalizedConfig);
   const devServer = new DevServer(compiler, logger, config.server);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

close  #288 

Solve the problem of port conflict and injection under multiserver

port conflicts need to be prevented when starting multiple servers at the same time

It is recommended that websocket and devserver use the same port for output

devserver and websocket prot conflict
devserve and ws use same port cause complate code
Injecting environment variables to listen for client ws hmr updates



<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
