### PR TITLE
feat: prevent port conflicts

### DIFF
--- a/.changeset/nasty-meals-laugh.md
+++ b/.changeset/nasty-meals-laugh.md
@@ -1,0 +1,5 @@
+---
+'@farmfe/core': patch
+---
+
+enable port auto-increment to prevent port conflict

--- a/examples/vue/farm.config.ts
+++ b/examples/vue/farm.config.ts
@@ -17,5 +17,8 @@ export default defineConfig({
       strictExports: true
     }
   },
+  server: {
+    strictPort: true,
+  },
   plugins: [farmJsPluginVue()]
 });

--- a/examples/vue/farm.config.ts
+++ b/examples/vue/farm.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
     }
   },
   server: {
-    strictPort: true,
+    strictPort: false,
   },
   plugins: [farmJsPluginVue()]
 });

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -274,7 +274,7 @@ export async function normalizeUserCompilationConfig(
 export const DEFAULT_HMR_OPTIONS: Required<UserHmrConfig> = {
   ignores: [],
   host: 'localhost',
-  port: 9801,
+  port: 9000,
   watchOptions: {
     awaitWriteFinish: 10
   }

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -360,6 +360,7 @@ export async function resolveUserConfig(
   }
   // check port availability: auto increment the port if a conflict occurs
   await DevServer.resolvePortConflict(userConfig, logger);
+
   return userConfig;
 }
 

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -193,6 +193,7 @@ const FarmConfigSchema = z
             })
           )
           .optional(),
+        strictPort: z.boolean().optional(),
         hmr: z
           .union([
             z.boolean(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,7 +37,7 @@ export async function start(
   const config: UserConfig = await resolveUserConfig(inlineConfig, logger);
 
   const normalizedConfig = await normalizeUserCompilationConfig(config);
-
+  // TODO conflict_port
   const compiler = new Compiler(normalizedConfig);
   const devServer = new DevServer(compiler, logger, config.server);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -20,7 +20,7 @@ import {
   UserConfig
 } from './config/index.js';
 import { DefaultLogger } from './utils/logger.js';
-import { DevServer, resolvePortConflict } from './server/index.js';
+import { DevServer } from './server/index.js';
 import { FileWatcher } from './watcher/index.js';
 import { Config } from '../binding/index.js';
 import { compilerHandler } from './utils/build.js';
@@ -34,15 +34,11 @@ export async function start(
 ): Promise<void> {
   const logger = inlineConfig.logger ?? new DefaultLogger();
   setProcessEnv('development');
-  let config: UserConfig = await resolveUserConfig(inlineConfig, logger);
-  // check port availability: auto increment the port if a conflict occurs
-  await resolvePortConflict(config, logger).then((res) => {
-    config = res.updatedConfig;
-  });
+  const config: UserConfig = await resolveUserConfig(inlineConfig, logger);
   const normalizedConfig = await normalizeUserCompilationConfig(config);
   // TODO conflict_port
   const compiler = new Compiler(normalizedConfig);
-  const devServer = new DevServer(compiler, logger, config.server);
+  const devServer = new DevServer(compiler, logger, config);
 
   if (normalizedConfig.config.mode === 'development') {
     normalizedConfig.jsPlugins.forEach((plugin: JsPlugin) =>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,7 +34,6 @@ export async function start(
 ): Promise<void> {
   const logger = inlineConfig.logger ?? new DefaultLogger();
   setProcessEnv('development');
-
   const config: UserConfig = await resolveUserConfig(inlineConfig, logger);
   const normalizedConfig = await normalizeUserCompilationConfig(config);
   // TODO conflict_port

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -34,6 +34,7 @@ export async function start(
 ): Promise<void> {
   const logger = inlineConfig.logger ?? new DefaultLogger();
   setProcessEnv('development');
+
   const config: UserConfig = await resolveUserConfig(inlineConfig, logger);
   const normalizedConfig = await normalizeUserCompilationConfig(config);
   // TODO conflict_port

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -36,7 +36,6 @@ export async function start(
   setProcessEnv('development');
   const config: UserConfig = await resolveUserConfig(inlineConfig, logger);
   const normalizedConfig = await normalizeUserCompilationConfig(config);
-  // TODO conflict_port
   const compiler = new Compiler(normalizedConfig);
   const devServer = new DevServer(compiler, logger, config);
 

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -149,10 +149,10 @@ export class DevServer implements ImplDevServer {
       userConfig.server,
       'development'
     );
-    let devPort = normalizedDevConfig.port;
 
+    let devPort = normalizedDevConfig.port;
     let hmrPort = DEFAULT_HMR_OPTIONS.port;
-    const { strictPort } = userConfig.server;
+    const { strictPort } = normalizedDevConfig;
     const httpServer = http.createServer();
 
     return new Promise((resolve, reject) => {

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -147,17 +147,18 @@ export class DevServer implements ImplDevServer {
   ): Promise<void> {
     let hmrPort = DEFAULT_HMR_OPTIONS.port;
     let devPort = userConfig.server.port;
-    const { strictPort } = userConfig.server;
+    // const { strictPort } = userConfig.server;
     const httpServer = http.createServer();
 
     return new Promise((resolve, reject) => {
       // attach listener to the server to listen for port conflict
       const onError = (e: Error & { code?: string }) => {
         if (e.code === 'EADDRINUSE') {
-          if (strictPort) {
-            httpServer.removeListener('error', onError);
-            reject(new Error(`Port ${devPort} is already in use`));
-          }
+          // if (strictPort) {
+          //   console.log('strictPort了啊');
+          //   httpServer.removeListener('error', onError);
+          //   reject(new Error(`Port ${devPort} is already in use`));
+          // }
           // TODO: if strictPort, throw Error(`Port ${port} is already in use`))
           logger.warn(`Port ${devPort} is in use, trying another one...`);
           // update hmrPort and devPort

--- a/packages/runtime-plugin-hmr/src/index.ts
+++ b/packages/runtime-plugin-hmr/src/index.ts
@@ -8,16 +8,18 @@ import { HmrUpdateResult } from './types';
 declare const FARM_HMR_PORT: string | undefined;
 declare const FARM_HMR_HOST: string | undefined;
 
-const port = Number(FARM_HMR_PORT || 9000);
+const port = Number(FARM_HMR_PORT || 9801);
 const host = FARM_HMR_HOST || 'localhost';
 
 export default <FarmRuntimePlugin>{
   name: 'farm-runtime-hmr-client-plugin',
   bootstrap(moduleSystem) {
-    console.log('[Farm HMR] connecting to the server...', port);
+    console.log('[Farm HMR] connecting to the server...');
 
     function connect() {
       // setup websocket connection
+      console.log('走进来链接了');
+
       const socket = new WebSocket(`ws://${host}:${port}`);
 
       // listen for the message from the server

--- a/packages/runtime-plugin-hmr/src/index.ts
+++ b/packages/runtime-plugin-hmr/src/index.ts
@@ -8,13 +8,13 @@ import { HmrUpdateResult } from './types';
 declare const FARM_HMR_PORT: string | undefined;
 declare const FARM_HMR_HOST: string | undefined;
 
-const port = Number(FARM_HMR_PORT || 9801);
+const port = Number(FARM_HMR_PORT || 9000);
 const host = FARM_HMR_HOST || 'localhost';
 
 export default <FarmRuntimePlugin>{
   name: 'farm-runtime-hmr-client-plugin',
   bootstrap(moduleSystem) {
-    console.log('[Farm HMR] connecting to the server...');
+    console.log('[Farm HMR] connecting to the server...', port);
 
     function connect() {
       // setup websocket connection

--- a/packages/runtime-plugin-hmr/src/index.ts
+++ b/packages/runtime-plugin-hmr/src/index.ts
@@ -18,10 +18,7 @@ export default <FarmRuntimePlugin>{
 
     function connect() {
       // setup websocket connection
-      console.log('走进来链接了');
-
       const socket = new WebSocket(`ws://${host}:${port}`);
-
       // listen for the message from the server
       // when the user save the file, the server will recompile the file(and its dependencies as long as its dependencies are changed)
       // after the file is recompiled, the server will generated a update resource and send its id to the client


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Aim: Preventing port conflicts by running an HTTP server to check port availability in advance
See issue #288 / PR #521 for a detailed discussion.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->
