### PR TITLE
fix: Temporarily resolve websocket port occupancy errors due to host inconsistencies

### DIFF
--- a/.changeset/long-planets-bake.md
+++ b/.changeset/long-planets-bake.md
@@ -1,0 +1,5 @@
+---
+'@farmfe/core': patch
+---
+
+fix: host different cause websocket port error

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -359,6 +359,7 @@ export async function resolveUserConfig(
   if (!userConfig.root) {
     userConfig.root = root;
   }
+
   // check port availability: auto increment the port if a conflict occurs
   await DevServer.resolvePortConflict(userConfig, logger);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
Temporarily resolve websocket port occupancy errors due to host inconsistencies
The next step is to solve the problem of websocket and http sharing a set of ports.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
