### PR TITLE
feat: reuse http server when hmr is not configured

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -176,6 +176,7 @@ export async function normalizeUserCompilationConfig(
     config.runtime.plugins.push(hmrClientPluginPath);
     config.define.FARM_HMR_PORT = String(normalizedDevServerConfig.hmr.port);
     config.define.FARM_HMR_HOST = normalizedDevServerConfig.hmr.host;
+    config.define.FARM_HMR_PATH = normalizedDevServerConfig.hmr.path;
   }
 
   // we should not deep merge compilation.input
@@ -273,7 +274,8 @@ export async function normalizeUserCompilationConfig(
 export const DEFAULT_HMR_OPTIONS: Required<UserHmrConfig> = {
   ignores: [],
   host: 'localhost',
-  port: 9801,
+  port: 9000,
+  path: '/__hmr',
   watchOptions: {
     awaitWriteFinish: 10
   }
@@ -305,7 +307,11 @@ export function normalizeDevServerOptions(
   if (mode === 'production' || options?.hmr === false) {
     hmr = false;
   } else {
-    hmr = merge({}, DEFAULT_HMR_OPTIONS, options?.hmr ?? {});
+    const devServerHostInfo = {
+      host: options?.host,
+      port: options?.port
+    };
+    hmr = merge({}, DEFAULT_HMR_OPTIONS, devServerHostInfo, options?.hmr ?? {});
   }
 
   return merge({}, DEFAULT_DEV_SERVER_OPTIONS, options, {

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -36,6 +36,7 @@ export interface UserHmrConfig {
   ignores?: string[];
   host?: string;
   port?: number;
+  path?: string;
   watchOptions?: {
     // this options only works in windows
     awaitWriteFinish?: number;

--- a/packages/core/src/server/middlewares/hmr.ts
+++ b/packages/core/src/server/middlewares/hmr.ts
@@ -44,7 +44,7 @@ export function hmrPlugin(context: DevServer) {
       context.server.on('upgrade', (request, socket, head) => {
         if (
           request.url === config.hmr.path &&
-          request.headers['sec-websocket-protocol'] === 'farmhmr'
+          request.headers['sec-websocket-protocol'] === 'farm_hmr'
         ) {
           context.ws.handleUpgrade(request, socket, head, (ws) => {
             context.ws.emit('connection', ws, request);

--- a/packages/core/src/server/middlewares/hmr.ts
+++ b/packages/core/src/server/middlewares/hmr.ts
@@ -37,10 +37,28 @@ import { DevServer } from '../index.js';
 export function hmrPlugin(context: DevServer) {
   const { config, _context, logger } = context;
   if (config.hmr) {
-    context.ws = new WebSocketServer({
-      port: config.hmr.port,
-      host: config.hmr.host
-    });
+    if (config.hmr.host === config.host && config.hmr.port === config.port) {
+      context.ws = new WebSocketServer({
+        noServer: true
+      });
+      context.server.on('upgrade', (request, socket, head) => {
+        if (
+          request.url === config.hmr.path &&
+          request.headers['sec-websocket-protocol'] === 'farmhmr'
+        ) {
+          context.ws.handleUpgrade(request, socket, head, (ws) => {
+            context.ws.emit('connection', ws, request);
+          });
+        }
+      });
+    } else {
+      context.ws = new WebSocketServer({
+        port: config.hmr.port,
+        host: config.hmr.host,
+        path: config.hmr.path
+      });
+    }
+
     // _context.app.use(hmr(context));
     context.hmrEngine = new HmrEngine(_context.compiler, context, logger);
   }

--- a/packages/runtime-plugin-hmr/src/index.ts
+++ b/packages/runtime-plugin-hmr/src/index.ts
@@ -20,7 +20,7 @@ export default <FarmRuntimePlugin>{
 
     function connect() {
       // setup websocket connection
-      const socket = new WebSocket(`ws://${host}:${port}${path}`, 'farmhmr');
+      const socket = new WebSocket(`ws://${host}:${port}${path}`, 'farm_hmr');
       // listen for the message from the server
       // when the user save the file, the server will recompile the file(and its dependencies as long as its dependencies are changed)
       // after the file is recompiled, the server will generated a update resource and send its id to the client

--- a/packages/runtime-plugin-hmr/src/index.ts
+++ b/packages/runtime-plugin-hmr/src/index.ts
@@ -7,9 +7,11 @@ import { HmrUpdateResult } from './types';
 
 declare const FARM_HMR_PORT: string | undefined;
 declare const FARM_HMR_HOST: string | undefined;
+declare const FARM_HMR_PATH: string | undefined;
 
-const port = Number(FARM_HMR_PORT || 9801);
+const port = Number(FARM_HMR_PORT || 9000);
 const host = FARM_HMR_HOST || 'localhost';
+const path = FARM_HMR_PATH || '/__hmr';
 
 export default <FarmRuntimePlugin>{
   name: 'farm-runtime-hmr-client-plugin',
@@ -18,7 +20,7 @@ export default <FarmRuntimePlugin>{
 
     function connect() {
       // setup websocket connection
-      const socket = new WebSocket(`ws://${host}:${port}`);
+      const socket = new WebSocket(`ws://${host}:${port}${path}`, 'farmhmr');
       // listen for the message from the server
       // when the user save the file, the server will recompile the file(and its dependencies as long as its dependencies are changed)
       // after the file is recompiled, the server will generated a update resource and send its id to the client


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

when `hmr.host` & `hmr.port` is same as dev server, reuse the dev server to handle hmr request.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

if reuse_mode, ws server need a unique path, so add a new property  `config.server.hmr.path`. the default value is '__hmr'

```ts
//server.hmr
{
path?:string; //default: '__hmr'
}
```

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**

#545 