### PR TITLE
fix: avoid the situation where the return value of additionalData is not a string

### DIFF
--- a/.changeset/fuzzy-bats-jump.md
+++ b/.changeset/fuzzy-bats-jump.md
@@ -1,0 +1,6 @@
+---
+'@farmfe/js-plugin-less': minor
+'@farmfe-examples/less': minor
+---
+
+Aovid the situation where the return value of additionalData is not a string

--- a/examples/less/farm.config.ts
+++ b/examples/less/farm.config.ts
@@ -32,6 +32,7 @@ export default defineConfig({
       if (path.basename(resolvePath,'.less') === 'index') {
         return `@hoverColor: #f10215;` + content;
       }
+      return content;
     },
   }) ],
 });

--- a/js-plugins/less/src/index.ts
+++ b/js-plugins/less/src/index.ts
@@ -40,7 +40,7 @@ export default function farmLessPlugin(
       filters: { resolvedPaths: ['\\.less$'] },
       async executor(param) {
         try {
-          let relData;
+          let relData = '';
           const fileRoot = path.dirname(param.resolvedPath);
           const configPaths = options.paths;
           if (
@@ -54,6 +54,10 @@ export default function farmLessPlugin(
                     param.resolvedPath
                   )}`
                 : `${options.additionalData}\n${param.content}`;
+            //  If the additionalData is a function, it might be return null or undefined, so we need to check it
+            if (typeof relData !== 'string') {
+              relData = param.content;
+            }
           } else {
             relData = param.content;
           }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
![image](https://github.com/farm-fe/farm/assets/72637162/7b1c68e2-ac08-491e-9198-dbc99075a65f)
When the additionalData function return nothing, the less api will complie `undefined`,it is illegal.
**BREAKING CHANGE:**
None
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
None