### PR TITLE
fix: css resource cannot find sourcemap

### DIFF
--- a/.changeset/late-emus-wait.md
+++ b/.changeset/late-emus-wait.md
@@ -2,4 +2,4 @@
 '@farmfe/core': patch
 ---
 
-fix css resource pot laod sourcemap
+fix css resource pot load sourcemap

--- a/.changeset/late-emus-wait.md
+++ b/.changeset/late-emus-wait.md
@@ -1,0 +1,5 @@
+---
+'@farmfe/core': patch
+---
+
+fix css resource pot laod sourcemap

--- a/crates/compiler/src/generate/render_resource_pots.rs
+++ b/crates/compiler/src/generate/render_resource_pots.rs
@@ -60,7 +60,12 @@ pub fn render_resource_pots_and_generate_resources(
     // to make sure the source map can be found.
     if let Some(mut source_map) = res.source_map {
       source_map.name = format!("{}.{}", r.name, source_map.resource_type.to_ext());
-      let source_mapping_url = format!("\n//# sourceMappingURL=/{}", source_map.name);
+
+      let source_mapping_url = if matches!(r.resource_type, ResourceType::Css) {
+        format!("\n/*# sourceMappingURL=/{} */", source_map.name)
+      } else {
+        format!("\n//# sourceMappingURL=/{}", source_map.name)
+      };
       r.bytes.append(&mut source_mapping_url.as_bytes().to_vec());
 
       resource_pot.add_resource(source_map.name.clone());


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Expect:
```css
/*# sourceMappingURL=/assets/multi-dimension-data-analysis_index_54e1.265a4b83.css.map */
```
Current:
```css
//# sourceMappingURL=/assets/multi-dimension-data-analysis_index_54e1.265a4b83.css.map
```


Step:

1. `git clone git@github.com:farm-fe/farm.git`
2. `cd examples/arco-pro`
3. `pnpm run build`
4. see `build/assets/*.css`

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
