### PR TITLE
fix: Avoid passing `null | undefined` values into JsWatcher

### DIFF
--- a/packages/core/src/watcher/configWatcher.ts
+++ b/packages/core/src/watcher/configWatcher.ts
@@ -22,8 +22,8 @@ export class ConfigWatcher {
     }
 
     const watchedFilesSet = new Set<string>([
-      ...(this.options.config?.config.envFiles || []),
-      ...(this.options.userConfig?.configFileDependencies || []),
+      ...(this.options.config?.config.envFiles ?? []),
+      ...(this.options.userConfig?.configFileDependencies ?? []),
       this.options.userConfig?.configFilePath
     ]);
 

--- a/packages/core/src/watcher/configWatcher.ts
+++ b/packages/core/src/watcher/configWatcher.ts
@@ -12,7 +12,7 @@ export class ConfigWatcher {
 
   constructor(private options: WatcherOptions) {
     if (!options) {
-      throw new Error('Invalid options provided to ConfigWatcher');
+      throw new Error('Invalid options provided to Farm JsConfigWatcher');
     }
   }
 

--- a/packages/core/src/watcher/configWatcher.ts
+++ b/packages/core/src/watcher/configWatcher.ts
@@ -10,18 +10,24 @@ export class ConfigWatcher {
   private watcher: JsFileWatcher;
   private _close = false;
 
-  constructor(private options: WatcherOptions) {}
+  constructor(private options: WatcherOptions) {
+    if (!options) {
+      throw new Error('Invalid options provided to ConfigWatcher');
+    }
+  }
 
   watch(callback: (file: string[]) => void) {
     async function handle(file: string[]) {
       callback(file);
     }
 
-    const watchedFiles = [
-      ...(this.options.config.config.envFiles ?? []),
-      ...(this.options.userConfig.configFileDependencies ?? []),
-      this.options.userConfig.configFilePath
-    ];
+    const watchedFilesSet = new Set<string>([
+      ...(this.options.config?.config.envFiles || []),
+      ...(this.options.userConfig?.configFileDependencies || []),
+      this.options.userConfig?.configFilePath
+    ]);
+
+    const watchedFiles = Array.from(watchedFilesSet).filter(Boolean);
 
     this.watcher = new JsFileWatcher((paths: string[]) => {
       if (this._close) return;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
