### PR TITLE
fix: resolve cannot find package 'vite' when using the yarn as packag…

### DIFF
--- a/packages/create-farm/templates/vue/package.json
+++ b/packages/create-farm/templates/vue/package.json
@@ -8,7 +8,8 @@
     "@farmfe/cli": "^0.6.1",
     "@farmfe/core": "^0.16.5",
     "@vitejs/plugin-vue": "^4.5.0",
-    "core-js": "^3.30.1"
+    "core-js": "^3.30.1",
+    "vite": "^5.0.12"
   },
   "scripts": {
     "dev": "farm start",


### PR DESCRIPTION
**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Resolve cannot find package 'vite' when using the yarn as package manager, adding `vite` into `devDependencies`.

Or we can add [.npmrc](https://github.com/nuxt/nuxt/blob/main/.npmrc) and enable `shamefully-hoist` to support more pacakge manager

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
#964