### PR TITLE
feat: add postinstall script for peer-gear when Yarn is installed

### DIFF
--- a/packages/create-farm/index.ts
+++ b/packages/create-farm/index.ts
@@ -160,6 +160,11 @@ function writePackageJson(dest: string, options: IResultType) {
 
   pkg.name = options.projectName;
 
+  if (isYarnInstalled) {
+    pkg.scripts = pkg.scripts ?? {};
+    pkg.scripts.postinstall = 'npx --yes peer-gear --install';
+  }
+
   const packageJsonPath = path.join(dest, 'package.json');
   const { name, ...rest } = pkg;
   const sortedPackageJson = { name, ...rest };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This pull request addresses the discussions in #965 by dynamically adding a script to the `package.json` when using Yarn. The purpose is to ensure that Yarn installs peer dependencies in a manner consistent with `npm` and `pnpm`.

Previously, we used the [check-peer-dependencies](https://github.com/christopherthielen/check-peer-dependencies) package for this purpose. While it is a reliable tool, it has a drawback – it installs `pre-release` (possibly `beta`) versions. To overcome this limitation, I've forked the repository and made modifications. The forked version now defaults to disabling `includePrerelease`, and I've included additional unit tests to enhance robustness.

Through thorough testing across various templates (including `Vanilla`, `React`, `Vue`, `Solid`, `Svelte`, `Lit`), this change has been validated, and all templates function as expected. This adjustment aims to improve the Developer Experience (DX) for those using Yarn as their package manager.






<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
#964