### PR TITLE
fix: failed build plugin tools

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -89,11 +89,10 @@ export const buildCli = () =>
   });
 
 // build farm-plugin-tools
-export const buildPluginTools = ()=>{
+export const buildPluginTools = () =>
   execa(DEFAULT_PACKAGE_MANAGER, ['build'], {
     cwd: PKG_PLUGIN_TOOLS
   });
-}
 
 // build dts command
 export const buildDts = () =>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

bootstrap script is not waiting for buildPluginTools to complete execution

**BREAKING CHANGE:**

**Related issue (if exists):**
