### PR TITLE
fix: tree shake variable assign

### DIFF
--- a/.changeset/spicy-hats-fly.md
+++ b/.changeset/spicy-hats-fly.md
@@ -1,0 +1,5 @@
+---
+'@farmfe/core': patch
+---
+
+variable assign need to retain

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/axios/dep.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/axios/dep.ts
@@ -64,3 +64,34 @@ prototype.toString = function toString(encoder) {
 };
 
 export default AxiosURLSearchParams;
+
+function AxiosURLSearchParams2(params, options) {
+  this._pairs = [];
+
+  // params && toFormData(params, this, options);
+  params;
+}
+
+function attach() {
+  const prototype = AxiosURLSearchParams2.prototype;
+
+  prototype.append = function append(name, value) {
+    this._pairs.push([name, value]);
+  };
+
+  prototype.toString = function toString(encoder) {
+    const _encode = encoder
+      ? function (value) {
+          return encoder.call(this, value, encode);
+        }
+      : encode;
+
+    return this._pairs
+      .map(function each(pair) {
+        return _encode(pair[0]) + '=' + _encode(pair[1]);
+      }, '')
+      .join('&');
+  };
+}
+
+export { AxiosURLSearchParams2 };

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/axios/index.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/axios/index.ts
@@ -1,3 +1,3 @@
-import Param from './dep';
+import Param, { AxiosURLSearchParams2 } from './dep';
 
-console.log(Param);
+console.log(Param, AxiosURLSearchParams2);

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/axios/output.js
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/axios/output.js
@@ -7,9 +7,17 @@
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
-    Object.defineProperty(exports, "default", {
-        enumerable: true,
-        get: function() {
+    function _export(target, all) {
+        for(var name in all)Object.defineProperty(target, name, {
+            enumerable: true,
+            get: all[name]
+        });
+    }
+    _export(exports, {
+        AxiosURLSearchParams2: function() {
+            return AxiosURLSearchParams2;
+        },
+        default: function() {
             return _default;
         }
     });
@@ -47,6 +55,10 @@
         }, "").join("&");
     };
     var _default = AxiosURLSearchParams;
+    function AxiosURLSearchParams2(params, options) {
+        this._pairs = [];
+        params;
+    }
 }
 ,
 "b5d64806":function  (module, exports, farmRequire, farmDynamicRequire) {
@@ -54,8 +66,8 @@
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
-    var _interop_require_default = farmRequire("@swc/helpers/_/_interop_require_default");
-    var _dep = _interop_require_default._(farmRequire("05ee5ec7"));
-    console.log(_dep.default);
+    var _interop_require_wildcard = farmRequire("@swc/helpers/_/_interop_require_wildcard");
+    var _dep = _interop_require_wildcard._(farmRequire("05ee5ec7"));
+    console.log(_dep.default, _dep.AxiosURLSearchParams2);
 }
 ,});(globalThis || window || global)['__farm_default_namespace__'].__farm_module_system__.setInitialLoadedResources([]);(globalThis || window || global)['__farm_default_namespace__'].__farm_module_system__.setDynamicModuleResourcesMap({  });var farmModuleSystem = (globalThis || window || global)['__farm_default_namespace__'].__farm_module_system__;farmModuleSystem.bootstrap();var entry = farmModuleSystem.require("b5d64806");

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/decl/class/dep.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/decl/class/dep.ts
@@ -1,7 +1,24 @@
 class Foo {}
 
 Foo.create = function () {
-  console.log('hello world');
+  return new Validate();
 };
 
-export default Foo;
+class Validate {
+  constructor(obj, options) {
+    this.obj = obj;
+    this.options = options;
+    this.globalConfig = BValidate.globalConfig;
+  }
+}
+
+var BValidate = function (obj, options) {
+  return new Validate(obj, Object.assign({ field: 'value' }, options));
+};
+BValidate.globalConfig = {};
+// 全局生效校验信息
+BValidate.setGlobalConfig = function (options) {
+  BValidate.globalConfig = options || {};
+};
+
+export { Foo, BValidate as default };

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/decl/class/index.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/decl/class/index.ts
@@ -1,3 +1,3 @@
-import Foo from './dep';
+import { Foo } from './dep';
 
 console.log(Foo);

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/decl/class/output.js
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/decl/class/output.js
@@ -7,18 +7,33 @@
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
-    Object.defineProperty(exports, "default", {
+    Object.defineProperty(exports, "Foo", {
         enumerable: true,
         get: function() {
-            return _default;
+            return Foo;
         }
     });
     class Foo {
     }
     Foo.create = function() {
-        console.log("hello world");
+        return new Validate();
     };
-    var _default = Foo;
+    class Validate {
+        constructor(obj, options){
+            this.obj = obj;
+            this.options = options;
+            this.globalConfig = BValidate.globalConfig;
+        }
+    }
+    var BValidate = function(obj, options) {
+        return new Validate(obj, Object.assign({
+            field: "value"
+        }, options));
+    };
+    BValidate.globalConfig = {};
+    BValidate.setGlobalConfig = function(options) {
+        BValidate.globalConfig = options || {};
+    };
 }
 ,
 "b5d64806":function  (module, exports, farmRequire, farmDynamicRequire) {
@@ -26,8 +41,7 @@
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
-    var _interop_require_default = farmRequire("@swc/helpers/_/_interop_require_default");
-    var _dep = _interop_require_default._(farmRequire("05ee5ec7"));
-    console.log(_dep.default);
+    var _dep = farmRequire("05ee5ec7");
+    console.log(_dep.Foo);
 }
 ,});(globalThis || window || global)['__farm_default_namespace__'].__farm_module_system__.setInitialLoadedResources([]);(globalThis || window || global)['__farm_default_namespace__'].__farm_module_system__.setDynamicModuleResourcesMap({  });var farmModuleSystem = (globalThis || window || global)['__farm_default_namespace__'].__farm_module_system__;farmModuleSystem.bootstrap();var entry = farmModuleSystem.require("b5d64806");


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

`BValidate.globalConfig`/``BValidate.setGlobalConfig`` need to retain

```ts
class Foo {}

Foo.create = function () {
  return new Validate();
};

class Validate {
  constructor(obj, options) {
    this.obj = obj;
    this.options = options;
    this.globalConfig = BValidate.globalConfig;
  }
}

var BValidate = function (obj, options) {
  return new Validate(obj, Object.assign({ field: 'value' }, options));
};
BValidate.globalConfig = {};
BValidate.setGlobalConfig = function (options) {
  BValidate.globalConfig = options || {};
};

export { Foo, BValidate as default };

```

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
