### PR TITLE
WIP: Fix some `build()` API BUG.

### DIFF
--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -78,10 +78,8 @@ async function getDefaultConfig(
   mode?: CompilationMode,
   isHandleServerPortConflict = true
 ) {
-  const mergedUserConfig = mergeInlineCliOptions({}, inlineOptions);
-
   const resolvedUserConfig = await resolveMergedUserConfig(
-    mergedUserConfig,
+    inlineOptions,
     undefined,
     inlineOptions.mode ?? mode
   );

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -131,7 +131,7 @@ export interface FarmCLIServerOptions {
   port?: number;
   open?: boolean;
   https?: SecureServerOptions;
-  hmr?: boolean;
+  hmr?: boolean | UserHmrConfig;
   host?: boolean | string;
   strictPort?: boolean;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I'm currently developing electron plugin of farm.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
- #1265 

**TODO:**
There are some other fixes in flighting.

- [ ] `compilation.external`  not work  when use `build()` API.
- [ ] `import "./__farm_runtime.33d087a6.mjs"` is not necessary when the `compilation.output.targetEnv` value is `node`.