### PR TITLE
fix(vite plugin): some vite plugins do not provide alias configuration errors

### DIFF
--- a/.changeset/nine-schools-visit.md
+++ b/.changeset/nine-schools-visit.md
@@ -1,0 +1,5 @@
+---
+'@farmfe/core': patch
+---
+
+fix(vite plugin): some vite plugins do not provide `alias` configuration errors

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -212,7 +212,7 @@ export async function resolveConfig(
   resolvedUserConfig.rustPlugins = rustPlugins;
 
   // Temporarily dealing with alias objects and arrays in js will be unified in rust in the future.]
-  if (resolvedUserConfig.compilation.resolve?.alias && vitePlugins.length) {
+  if (vitePlugins.length) {
     resolvedUserConfig.compilation.resolve.alias = getAliasEntries(
       resolvedUserConfig.compilation.resolve.alias
     );

--- a/packages/core/src/plugin/js/farm-to-vite-config.ts
+++ b/packages/core/src/plugin/js/farm-to-vite-config.ts
@@ -33,7 +33,7 @@ export function farmUserConfigToViteConfig(config: UserConfig): ViteUserConfig {
     // @ts-ignore ignore this error
     command: config.compilation?.mode === 'production' ? 'build' : 'serve',
     resolve: {
-      alias: config.compilation?.resolve?.alias,
+      alias: config.compilation?.resolve?.alias ?? [],
       extensions: config.compilation?.resolve?.extensions,
       mainFields: config.compilation?.resolve?.mainFields,
       conditions: config.compilation?.resolve?.conditions,

--- a/packages/core/src/plugin/js/farm-to-vite-config.ts
+++ b/packages/core/src/plugin/js/farm-to-vite-config.ts
@@ -33,7 +33,7 @@ export function farmUserConfigToViteConfig(config: UserConfig): ViteUserConfig {
     // @ts-ignore ignore this error
     command: config.compilation?.mode === 'production' ? 'build' : 'serve',
     resolve: {
-      alias: config.compilation?.resolve?.alias ?? [],
+      alias: config.compilation?.resolve?.alias,
       extensions: config.compilation?.resolve?.extensions,
       mainFields: config.compilation?.resolve?.mainFields,
       conditions: config.compilation?.resolve?.conditions,

--- a/packages/core/src/utils/plugin-utils.ts
+++ b/packages/core/src/utils/plugin-utils.ts
@@ -53,7 +53,7 @@ export function throwError(pluginName: string, type: string, error: Error) {
 export function getAliasEntries(
   entries: Record<string, string> | Array<Alias>
 ): any {
-  if (!entries) {
+  if (!entries || !Object.keys(entries).length) {
     return [];
   }
 


### PR DESCRIPTION
…, resulting in errors

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

当某些`vite config` 没有配置`resolve?.alias`的时候为`undefined`会导致出现`resolve?.alias.some is not function`不能正常启动服务。
可以使用[vite-adapter-vue2.7](https://github.com/farm-fe/farm/tree/main/examples/vite-adapter-vue2.7)项目进行复现。
将[farm config L7-L15配置](https://github.com/farm-fe/farm/blob/main/examples/vite-adapter-vue2.7/farm.config.ts#L7-L15)移除。

这里提供一个默认值避免获取`resolve?.alias`的时候为`undefined`。
这里给vite config 提供一个`Alias[]`数组(空数组）,目前这样配置可以正常启动服务，
![image](https://github.com/farm-fe/farm/assets/81673017/2292b6fc-2bfc-488e-a62d-d6799d70e0bd)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
