### PR TITLE
fix: external inject logic

### DIFF
--- a/.changeset/spotty-shrimps-teach.md
+++ b/.changeset/spotty-shrimps-teach.md
@@ -1,0 +1,6 @@
+---
+"@farmfe/core": patch
+---
+
+1. external injectlogic
+2. better tip

--- a/crates/plugin_runtime/src/handle_entry_resources.rs
+++ b/crates/plugin_runtime/src/handle_entry_resources.rs
@@ -238,7 +238,7 @@ fn get_entry_resource_and_dep_resources_name(
 
     if let Some(entry) = &resource_pot.entry_module {
       if entry != &module.id {
-        panic!("entry module is not equal to module id");
+        panic!("entry module is not equal to module id, maybe entry imports another entry");
       }
 
       for resource_id in resource_pot.resources() {

--- a/crates/plugin_runtime/src/lib.rs
+++ b/crates/plugin_runtime/src/lib.rs
@@ -446,13 +446,11 @@ impl Plugin for FarmPluginRuntime {
         let mut external_objs = Vec::new();
 
         for source in external_modules {
-          let replace_source = match external_config.find_match(&source) {
-            Some(v) => Ok(v.source(&source)),
-            None => Err(CompilationError::GenericError(format!(
-              "cannot find external source: {:?}",
-              source
-            ))),
-          }?;
+          let replace_source = external_config
+            .find_match(&source)
+            .map(|v| v.source(&source))
+            // it's maybe from plugin
+            .unwrap_or(source.clone());
 
           let source_obj = format!("(globalThis||window||{{}})['{}']||{{}}", replace_source);
           external_objs.push(if context.config.output.format == ModuleFormat::EsModule {

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -703,7 +703,7 @@ async function readConfigFile(
     // Change to vm.module of node or loaders as far as it is stable
     const userConfig = (await import(filePath as string)).default;
     try {
-      // fs.unlink(filePath, () => void 0);
+      fs.unlink(filePath, () => void 0);
     } catch {
       /** do nothing */
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

- better error tip
- external inject logic

external maybe from external

```ts
export function autoExternal(): JsPlugin {
    return {
        priority: -Infinity,
        name: `${CLI_NAME}:AutoExternal`,
        resolve: {
            filters: {
                sources: ['.*'],
                importers: ['.*'],
            },
            async executor(param): Promise<PluginResolveHookResult> {
                logger.debug(`${param.source} not found, it to be set external`);
                return {
                    resolvedPath: param.source,
                    external: true,
                };
            },
        },
    };
}
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
