### PR TITLE
refactor(create-farm): rewrite `create-farm` with `clap`

### DIFF
--- a/.changeset/serious-bears-grin.md
+++ b/.changeset/serious-bears-grin.md
@@ -1,0 +1,5 @@
+---
+"create-farm": patch
+---
+
+Refactor create-farm with clap

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad186efb764318d35165f1758e7dcef3b10628e26d41a44bc5550652e6804391"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "any_ascii"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -563,6 +612,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b3edb18336f4df585bc9aa31dd99c036dfa5dc5e9a2939a722a188f3a8970d"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c09dd5ada6c6c78075d6fd0da3f90d8080651e2d6cc8eb2f1aaa4034ced708"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
 name = "clipboard-win"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +707,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
 
 [[package]]
 name = "combine"
@@ -849,11 +944,11 @@ name = "create-farm"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clap",
  "dialoguer",
  "napi",
  "napi-build",
  "napi-derive",
- "pico-args",
  "rust-embed",
 ]
 
@@ -1066,13 +1161,14 @@ dependencies = [
 
 [[package]]
 name = "dialoguer"
-version = "0.10.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c6f2989294b9a498d3ad5491a79c6deb604617378e1cdc4bfc1c1361fe2f87"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
 dependencies = [
  "console",
  "shell-words",
  "tempfile",
+ "thiserror",
  "zeroize",
 ]
 
@@ -2210,6 +2306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2573,12 @@ name = "is_ci"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616cde7c720bb2bb5824a224687d8f77bfd38922027f01d825cd7453be5099fb"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
 name = "itertools"
@@ -3424,12 +3532,6 @@ checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
 dependencies = [
  "siphasher",
 ]
-
-[[package]]
-name = "pico-args"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project"
@@ -4569,6 +4671,12 @@ dependencies = [
  "swc_macros_common",
  "syn 2.0.60",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
@@ -6130,6 +6238,12 @@ name = "urlencoding"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/crates/create-farm-rs/Cargo.toml
+++ b/crates/create-farm-rs/Cargo.toml
@@ -15,8 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
-pico-args = "0.5"
-dialoguer = "0.10"
+dialoguer = "0.11"
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = { version = "2.15.2", default-features = false, features = [
   "napi4",
@@ -24,6 +23,7 @@ napi = { version = "2.15.2", default-features = false, features = [
 ] }
 napi-derive = "2.15.2"
 rust-embed = { version = "8.3", features = [ "compression", "interpolate-folder-path" ] }
+clap = { version = "4.5.8", features = ["derive"] }
 
 [build-dependencies]
 napi-build = "2.0.1"

--- a/crates/create-farm-rs/src/args.rs
+++ b/crates/create-farm-rs/src/args.rs
@@ -1,14 +1,21 @@
-use crate::{package_manager::PackageManager, template::Template, utils::colors::*};
-use std::ffi::OsString;
-use pico_args::Arguments;
+use crate::{package_manager::PackageManager, template::Template};
+use clap::Parser;
 
-#[derive(Debug)]
+#[derive(Parser, Debug)]
+#[command(
+  name = "create-farm",
+  about,
+  long_about = None,
+  version,
+)]
 pub struct Args {
+  #[arg(help = "Project name")]
   pub project_name: Option<String>,
+  #[arg(short, long, help = "Package manager to use")]
   pub manager: Option<PackageManager>,
+  #[arg(short, long, help = "Project template to use")]
   pub template: Option<Template>,
 }
-
 
 impl Default for Args {
   fn default() -> Self {
@@ -18,31 +25,4 @@ impl Default for Args {
       template: Some(Template::Vanilla),
     }
   }
-}
-
-
-pub fn parse(argv: Vec<OsString>, bin_name: Option<String>) -> anyhow::Result<Args> {
-  let mut pargs = Arguments::from_vec(argv);
-
-  if pargs.contains(["-h", "--help"]) {
-      let help = format!(
-          r#""#
-      );
-
-      println!("{help}");
-      std::process::exit(0);
-  }
-  if pargs.contains(["-v", "--version"]) {
-      println!("{}", env!("CARGO_PKG_VERSION"));
-      std::process::exit(0);
-  }
-
-
-  let args = Args {
-      manager: pargs.opt_value_from_str(["-m", "--manager"])?,
-      template: pargs.opt_value_from_str(["-t", "--template"])?,
-      project_name: pargs.opt_free_from_str()?,
-  };
-
-  Ok(args)
 }

--- a/crates/create-farm-rs/src/package_manager.rs
+++ b/crates/create-farm-rs/src/package_manager.rs
@@ -57,7 +57,7 @@ impl<'a> PackageManager {
   ];
 
   /// Node.js managers
-  pub const NODE: &'a [PackageManager] = &[
+  pub const _NODE: &'a [PackageManager] = &[
     PackageManager::Pnpm,
     PackageManager::Yarn,
     PackageManager::Npm,
@@ -85,7 +85,7 @@ impl PackageManager {
     }
   }
 
-  pub const fn templates(&self) -> &[Template] {
+  pub const fn _templates(&self) -> &[Template] {
     match self {
       PackageManager::Pnpm | PackageManager::Yarn | PackageManager::Npm | PackageManager::Bun => &[
         Template::Vanilla,
@@ -108,7 +108,6 @@ impl PackageManager {
       PackageManager::Yarn => Some("yarn"),
       PackageManager::Npm => Some("npm install"),
       PackageManager::Bun => Some("bun install"),
-      _ => None,
     }
   }
 
@@ -121,7 +120,7 @@ impl PackageManager {
     }
   }
 
-  pub const fn is_node(&self) -> bool {
+  pub const fn _is_node(&self) -> bool {
     matches!(
       self,
       PackageManager::Pnpm | PackageManager::Yarn | PackageManager::Npm | PackageManager::Bun,

--- a/crates/create-farm-rs/src/template.rs
+++ b/crates/create-farm-rs/src/template.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, fmt::Display, fs, io::Write, path, str::FromStr};
+use std::{collections::HashMap, fmt::Display, fs, path, str::FromStr};
 
 use crate::{
   package_manager::PackageManager,
@@ -213,7 +213,6 @@ impl Template {
         ElectronSubTemplate::Preact => "\x1b[38;2;255;215;0mElectron with Preact\x1b[39m",
       },
       Template::Nestjs => "\x1b[38;2;255;102;102mNestJS - (https://nestjs.com/)\x1b[39m",
-      _ => unreachable!(),
     }
   }
 }
@@ -266,7 +265,7 @@ impl<'a> Template {
   pub fn render(
     &self,
     target_dir: &path::Path,
-    pkg_manager: PackageManager,
+    _pkg_manager: PackageManager,
     project_name: &str,
     package_name: &str,
   ) -> anyhow::Result<()> {
@@ -302,7 +301,7 @@ impl<'a> Template {
           // skip manifest
           name if name.starts_with("%(") && name[1..].contains(")%") => {
             let mut s = name.strip_prefix("%(").unwrap().split(")%");
-            let (mut flags, name) = (
+            let (mut _flags, _name) = (
               s.next().unwrap().split('-').collect::<Vec<_>>(),
               s.next().unwrap(),
             );
@@ -348,7 +347,7 @@ impl<'a> Template {
     let skip_count = current_template_name.matches('/').count() + 1;
     for file in EMBEDDED_TEMPLATES::iter().filter(|e| {
       let path = path::PathBuf::from(e.to_string());
-      let components: Vec<_> = path.components().collect();
+      let _components: Vec<_> = path.components().collect();
       let path_str = path.to_string_lossy();
       // let template_name = components.first().unwrap().as_os_str().to_str().unwrap();
       path_str.starts_with(&current_template_name)


### PR DESCRIPTION
**Description:**

- Use `clap` instead of `pico-args` to parse args
- Use `clap` to implement cli helper
- Fix all warnings of dead codes
- Fix `--manager` takes no effect
- Update dependencies and remove `pico-args`

**Looks Like:**

![image](https://github.com/farm-fe/farm/assets/46275354/a5f48acc-8a9e-4551-b0b2-21d562306c7b)


**Related issue:** #1277
