### PR TITLE
fix(template): replace 'class' with 'className' in image tag to resol…

### DIFF
--- a/.changeset/nervous-peaches-reply.md
+++ b/.changeset/nervous-peaches-reply.md
@@ -1,5 +1,5 @@
 ---
-"create-farm": minor
+"create-farm": patch
 ---
 
 Corrected the usage of class to className in an image tag within the Tauri > React template to resolve build errors.

--- a/.changeset/nervous-peaches-reply.md
+++ b/.changeset/nervous-peaches-reply.md
@@ -1,0 +1,5 @@
+---
+"create-farm": minor
+---
+
+Corrected the usage of class to className in an image tag within the Tauri > React template to resolve build errors.

--- a/crates/create-farm-rs/templates/tauri/react/src/App.tsx
+++ b/crates/create-farm-rs/templates/tauri/react/src/App.tsx
@@ -19,7 +19,7 @@ function App() {
 
       <div className="row">
         <a href="https://farmfe.org/" target="_blank">
-          <img src={FarmLogo} class="logo" alt="Farm logo" />
+          <img src={FarmLogo} className="logo" alt="Farm logo" />
         </a>
         <a href="https://tauri.app" target="_blank">
           <img src="/tauri.svg" className="logo tauri" alt="Tauri logo" />


### PR DESCRIPTION
**Description:**

The Tauri > React template is using class instead of className in an image tag, which produces an error when running npm run build.

```jsx
// Before
<a href="https://farmfe.org/" target="_blank">
  <img src={FarmLogo} class="logo" alt="Farm logo" />
</a>

// After
<a href="https://farmfe.org/" target="_blank">
  <img src={FarmLogo} className="logo" alt="Farm logo" />
</a>
```

**BREAKING CHANGE:**


**Related issue (if exists):**
