### PR TITLE
fix: ignore non-utf8 error when getting file contents

### DIFF
--- a/.changeset/short-roses-dream.md
+++ b/.changeset/short-roses-dream.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+Ignore non-utf8 error when getting file contents

--- a/crates/toolkit/src/fs/mod.rs
+++ b/crates/toolkit/src/fs/mod.rs
@@ -12,12 +12,7 @@ pub const ENTRY_NAME: &str = "[entryName]";
 /// read content of the path, return utf8 string.
 pub fn read_file_utf8(path: &str) -> Result<String> {
   let raw = read_file_raw(path)?;
-  String::from_utf8(raw).map_err(|e| {
-    CompilationError::GenericError(format!(
-      "File `{}` is not utf8! Detailed Error: {:?}",
-      path, e
-    ))
-  })
+  Ok(String::from_utf8_lossy(&raw).into_owned())
 }
 
 /// read content of the path, return bytes.

--- a/crates/toolkit/tests/fixtures/script/index.js
+++ b/crates/toolkit/tests/fixtures/script/index.js
@@ -1,3 +1,7 @@
+/**
+ * 设置屏幕方向，可设置以下值
+ */
+
 import a from './a';
 import b from './b';
 

--- a/crates/toolkit/tests/fixtures/script/index.jsx
+++ b/crates/toolkit/tests/fixtures/script/index.jsx
@@ -1,3 +1,7 @@
+/**
+ * 设置屏幕方向，可设置以下值
+ */
+
 import a from './a';
 import b from './b';
 

--- a/crates/toolkit/tests/fixtures/script/index.ts
+++ b/crates/toolkit/tests/fixtures/script/index.ts
@@ -1,3 +1,7 @@
+/**
+ * 设置屏幕方向，可设置以下值
+ */
+
 import a from './a';
 import b from './b';
 

--- a/crates/toolkit/tests/fixtures/script/index.tsx
+++ b/crates/toolkit/tests/fixtures/script/index.tsx
@@ -1,3 +1,7 @@
+/**
+ * 设置屏幕方向，可设置以下值
+ */
+
 import a from './a';
 import b from './b';
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
<img width="1465" alt="image" src="https://github.com/user-attachments/assets/7990254c-d2fc-4137-8bb7-97c8df9ce97b">
When the user file content appears to be illegal utf8, the current error exception is not friendly. At the same time we should not throw such exceptions to developers
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
None
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
None