### PR TITLE
feat(plugins): add primitives to support sub-compiler usage

### DIFF
--- a/crates/compiler/src/lib.rs
+++ b/crates/compiler/src/lib.rs
@@ -79,6 +79,13 @@ impl Compiler {
 
     plugins.append(&mut plugin_adapters);
 
+    Self::new_without_internal_plugins(config, plugins)
+  }
+
+  pub fn new_without_internal_plugins(
+    config: Config,
+    mut plugins: Vec<Arc<dyn Plugin>>,
+  ) -> Result<Self> {
     // sort plugins by priority to make larger priority plugin run first
     plugins.sort_by_key(|b| std::cmp::Reverse(b.priority()));
 

--- a/crates/core/src/module/module_graph.rs
+++ b/crates/core/src/module/module_graph.rs
@@ -664,6 +664,24 @@ impl ModuleGraph {
       .iter()
       .any(|(_, edge)| edge.is_dynamic())
   }
+
+  pub fn copy_to(&self, other: &mut Self, overwrite: bool) -> Result<()> {
+    let mut new_modules = Vec::<ModuleId>::new();
+    for module in self.modules() {
+      if overwrite || !other.has_module(&module.id) {
+        other.add_module(module.clone());
+        new_modules.push(module.id.clone());
+      }
+    }
+
+    for module_id in &new_modules {
+      for (dep, edge) in self.dependencies(module_id) {
+        other.add_edge(module_id, &dep, edge.clone())?;
+      }
+    }
+
+    Ok(())
+  }
 }
 
 impl Default for ModuleGraph {

--- a/crates/core/src/plugin/plugin_driver.rs
+++ b/crates/core/src/plugin/plugin_driver.rs
@@ -26,7 +26,7 @@ use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 pub struct PluginDriver {
-  plugins: Vec<Arc<dyn Plugin>>,
+  pub plugins: Vec<Arc<dyn Plugin>>,
   record: bool,
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I'm building framework around farm that requires "sub-build"s. The main problem blocking me from achieving this is the inability to access the plugins from the current compiler context/plugin driver.

With these changes, I am able to create a sub-compiler to create a sub-build like this:

```
fn load(
  &self,
  param: &PluginLoadHookParam,
  context: &Arc<CompilationContext>,
  hook_context: &PluginHookContext,
) -> Result<Option<PluginLoadHookResult>> {
  let mut config = context.config.as_ref().clone();
  config.progress = false;
  config.input = HashMap::new();
  config.input.insert(String::from("client"), "anothermodule.ts");

  let compiler =
    Compiler::new_without_internal_plugins(config, context.plugin_driver.plugins.clone())?;

  // copy module graph to new compiler
  context
    .module_graph
    .read()
    .copy_to(&mut *compiler.context().module_graph.write(), true)?;

  compiler.compile()?;

  let resource_map = compiler.context().resource_map.lock();
  let js = String::from_utf8(resource_map.get("client.js").unwrap().bytes.clone()).unwrap();

  // ...
}
```

Note that there are a few issues with this approach:
- a new thread pool is created for each sub-compiler,
- modules may be cloned twice per sub-compiler, once when creating each sub-compiler and once when updating the main module graph with newly cached modules, and
- my plugin binary becomes more bloated than necessary because the entire compiler crate including all other default plugins and dependencies are compiled and bundled with my plugin logic.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

None.

**Related issue (if exists):**
