### PR TITLE
chore(v2): Integrate middleware and htmlfallback middlewear usage

### DIFF
--- a/.changeset/loud-dogs-double.md
+++ b/.changeset/loud-dogs-double.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": major
+---
+
+collect htmlFallbackMiddleware

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
   "biome.enabled": true,
   "editor.defaultFormatter": "biomejs.biome",
   "[typescript]": {
-    "editor.defaultFormatter": "esbenp.prettier-vscode"
+    "editor.defaultFormatter": "vscode.typescript-language-features"
   },
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"

--- a/examples/refactor-react/base.html
+++ b/examples/refactor-react/base.html
@@ -9,6 +9,6 @@
   <title>Farm + React + TS</title>
 </head>
 <body>
-  <div id="root">dfgdfgfdgdfgdfgdfgdfg</div>
+  <div id="root">asdsadasdasdasd</div>
 </body>
 </html>

--- a/examples/refactor-react/farm.config.ts
+++ b/examples/refactor-react/farm.config.ts
@@ -12,6 +12,11 @@ export default defineConfig({
     compilerPlugin(),
   ],
   compilation: {
+    input: {
+      index: path.resolve(__dirname, "index.html"),
+      base: path.resolve(__dirname, 'base.html'),
+      about: path.resolve(__dirname, 'about.html'),
+    },
     // persistentCache: false,
     persistentCache: {
       cacheDir: "node_modules/.adny",
@@ -29,6 +34,7 @@ export default defineConfig({
   // timeUnit: "s",
   server: {
     port: 8854,
+    // appType: "mpa",
   },
 });
 

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -541,8 +541,8 @@ export const DEFAULT_DEV_SERVER_OPTIONS: NormalizedServerConfig = {
   open: false,
   strictPort: false,
   cors: false,
-  spa: true,
   middlewares: [],
+  appType: 'spa',
   writeToDisk: false
 };
 

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -70,7 +70,7 @@ const serverSchema = z
     open: z.boolean().optional(),
     https: z.custom<SecureServerOptions>(),
     cors: z.boolean().optional(),
-    spa: z.boolean().optional(),
+    appType: z.enum(['spa', 'mpa', 'custom']).optional(),
     proxy: z
       .record(
         z

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -63,7 +63,7 @@ export interface UserServerConfig {
   host?: string | boolean;
   cors?: boolean | any;
   // whether to serve static assets in spa mode, default to true
-  spa?: boolean;
+  appType?: 'spa' | 'mpa' | 'custom';
   middlewares?: DevServerMiddleware[];
   middlewareMode?: boolean | string;
   writeToDisk?: boolean;

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -92,6 +92,7 @@ export interface ServerOptions extends CommonServerOptions {
         server: http.Server;
       };
   origin?: string;
+  appType?: 'spa' | 'mpa' | 'custom';
 }
 
 type ServerConfig = CommonServerOptions & NormalizedServerConfig;
@@ -552,7 +553,7 @@ export class Server extends httpServer {
   #initializeMiddlewares() {
     this.middlewares.use(hmrPingMiddleware());
 
-    const { proxy, middlewareMode, cors } = this.serverOptions;
+    const { proxy, middlewareMode, cors, appType } = this.serverOptions;
 
     if (cors) {
       this.middlewares.use(
@@ -585,16 +586,17 @@ export class Server extends httpServer {
       this.middlewares.use(adaptorViteMiddleware(this));
     }
 
+    this.middlewares.use(resourceMiddleware(this));
+
     this.postConfigureServerHooks.reduce((_, fn) => {
       if (typeof fn === 'function') fn();
     }, null);
 
-    // TODO todo add appType 这块要判断 单页面还是 多页面 多 html 处理不一样
-    this.middlewares.use(htmlFallbackMiddleware(this));
+    if (appType === 'spa' || appType === 'mpa') {
+      this.middlewares.use(htmlFallbackMiddleware(this));
 
-    this.middlewares.use(resourceMiddleware(this));
-
-    this.middlewares.use(notFoundMiddleware());
+      this.middlewares.use(notFoundMiddleware());
+    }
   }
 
   /**

--- a/packages/core/src/server/middlewares/resource.ts
+++ b/packages/core/src/server/middlewares/resource.ts
@@ -28,10 +28,6 @@ export function resourceMiddleware(app: Server): Connect.NextHandleFunction {
     const url = cleanUrl(req.url);
 
     const { compiler, resolvedUserConfig: config, publicPath } = app;
-    // TODO resolve html but not input file html
-    // htmlFallbackMiddleware appends '.html' to URLs
-    // if (url?.endsWith('.html') && req.headers['sec-fetch-dest'] !== 'script') {
-    // }
 
     if (compiler._isInitialCompile) {
       await compiler.waitForInitialCompileFinish();
@@ -57,8 +53,6 @@ export function resourceMiddleware(app: Server): Connect.NextHandleFunction {
     }
 
     // publicPath
-    // 处理找不到资源的情况
-
     const { resourceWithoutPublicPath } = normalizePathByPublicPath(
       publicPath,
       url
@@ -88,29 +82,6 @@ export function resourceMiddleware(app: Server): Connect.NextHandleFunction {
       return;
     }
 
-    // TODO prepare add spa config or else
-    // if (config.spa !== false) {
-    //   let indexHtml = compiler.resources()["index.html"];
-
-    //   if (indexHtml) {
-    //     res.setHeader("Content-Type", "text/html");
-    //     res.end(indexHtml);
-    //     return;
-    //   }
-    // }
-    // // TODO redefine spa mpa
-    // let indexHtml = compiler.resources()['index.html'];
-
-    // if (indexHtml) {
-    //   res.setHeader('Content-Type', 'text/html');
-    //   res.end(indexHtml);
-    //   return;
-    // }
-
-    // 如果找不到任何匹配的资源，返回 404
-    // res.statusCode = 404;
-    // res.end('Not found');
-    // return;
     next();
   };
 }

--- a/packages/core/src/server/middlewares/resource.ts
+++ b/packages/core/src/server/middlewares/resource.ts
@@ -98,18 +98,20 @@ export function resourceMiddleware(app: Server): Connect.NextHandleFunction {
     //     return;
     //   }
     // }
-    // TODO redefine spa mpa
-    let indexHtml = compiler.resources()['index.html'];
+    // // TODO redefine spa mpa
+    // let indexHtml = compiler.resources()['index.html'];
 
-    if (indexHtml) {
-      res.setHeader('Content-Type', 'text/html');
-      res.end(indexHtml);
-      return;
-    }
+    // if (indexHtml) {
+    //   res.setHeader('Content-Type', 'text/html');
+    //   res.end(indexHtml);
+    //   return;
+    // }
 
     // 如果找不到任何匹配的资源，返回 404
-    res.statusCode = 404;
-    res.end('Not found');
+    // res.statusCode = 404;
+    // res.end('Not found');
+    // return;
+    next();
   };
 }
 

--- a/packages/core/src/utils/plugin-utils.ts
+++ b/packages/core/src/utils/plugin-utils.ts
@@ -83,3 +83,8 @@ export function transformAliasWithVite(
     return acc;
   }, {});
 }
+
+export function removeSlash(path: string) {
+  if (!path) return '';
+  return path.replace(/^[/\\]+/, '');
+}

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -120,44 +120,51 @@ export const buildDts = () =>
 export const rustPlugins = () => batchBuildPlugins(PKG_RUST_PLUGIN);
 
 export const buildJsPlugins = async () => {
-  const jsPluginDirs = fs.readdirSync(JS_PLUGINS_DIR).filter((file) => {
-    return (
-      fs.statSync(join(JS_PLUGINS_DIR, file)).isDirectory() &&
-      !excludedJsPlugin.includes(file)
-    );
-  });
+  await execa(
+    DEFAULT_PACKAGE_MANAGER,
+    ['--filter', './js-plugins/**', 'build'],
+    {
+      cwd: CWD
+    }
+  );
+  // const jsPluginDirs = fs.readdirSync(JS_PLUGINS_DIR).filter((file) => {
+  //   return (
+  //     fs.statSync(join(JS_PLUGINS_DIR, file)).isDirectory() &&
+  //     !excludedJsPlugin.includes(file)
+  //   );
+  // });
 
-  const total = jsPluginDirs.length;
-  console.log('\n')
-  logger(`Found ${total} JS plugins to build \n`, { color: 'blue' });
+  // const total = jsPluginDirs.length;
+  // console.log('\n')
+  // logger(`Found ${total} JS plugins to build \n`, { color: 'blue' });
 
-  for (const pluginDir of jsPluginDirs) {
-    const pluginPath = resolve(JS_PLUGINS_DIR, pluginDir);
-    await runTask(
-      `Built JS Plugin: ${pluginDir}`,
-      async () => {
-        const spinner = createSpinner(`Building ${pluginDir}`).start();
-        try {
-          if (!existsSync(join(pluginPath, 'package.json'))) {
-            spinner.warn({ text: `Skipping ${pluginDir}: No package.json found` });
-            return;
-          }
+  // for (const pluginDir of jsPluginDirs) {
+  //   const pluginPath = resolve(JS_PLUGINS_DIR, pluginDir);
+  //   await runTask(
+  //     `Built JS Plugin: ${pluginDir}`,
+  //     async () => {
+  //       const spinner = createSpinner(`Building ${pluginDir}`).start();
+  //       try {
+  //         if (!existsSync(join(pluginPath, 'package.json'))) {
+  //           spinner.warn({ text: `Skipping ${pluginDir}: No package.json found` });
+  //           return;
+  //         }
 
-          await execa(DEFAULT_PACKAGE_MANAGER, ['build'], {
-            cwd: pluginPath,
-            stdio: 'pipe',
-          });
+  //         await execa(DEFAULT_PACKAGE_MANAGER, ['build'], {
+  //           cwd: pluginPath,
+  //           stdio: 'pipe',
+  //         });
 
-          spinner.success({ text: `Built JS plugin: ${pluginDir}` });
-        } catch (error) {
-          spinner.error({ text: `Failed to build JS plugin: ${pluginDir}` });
-          throw error;
-        }
-      },
-      'Building',
-      'Build'
-    );
-  }
+  //         spinner.success({ text: `Built JS plugin: ${pluginDir}` });
+  //       } catch (error) {
+  //         spinner.error({ text: `Failed to build JS plugin: ${pluginDir}` });
+  //         throw error;
+  //       }
+  //     },
+  //     'Building',
+  //     'Build'
+  //   );
+  // }
 };
 
 export const buildRustPlugins = async () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

Integrating farm dev server has `all middleware` functions and the impact of `appType` on configuring `spa`, `mpa` and `custom` fields functions


The following is a brief explanation of the core points of this pr, only about the appType function

<img width="2252" alt="image" src="https://github.com/user-attachments/assets/c9c2b48f-c313-4920-a311-733f3fcd4fec">

The functions of each part of the middleware in the following order are as follows

- corsMiddleware: Allowing the server to control which cross-domain requests can be accepted by the browser
- proxyMiddleware: Mainly used to process proxy requests in the development server
- publicPathMiddleware: Routing control to be used to handle static resource and URL redirects
- adapterViteMiddleware: A middleware used to process resource files in Vite development mode. Its main purpose is to ensure that certain resources (such as images or fonts) are compiled and provided correctly in development mode
- lazyComplationMiddleware: Handle routing lazy loading middleware
- resourceMiddleware: Handle all resouce to change browser url
- publicMiddleware: Is a middleware used to process static resources, mainly used to provide static files in public directories in the development server
- notFoundMiddleware: return 404
- htmlFallbackMiddleware: Returns different html benchmark resources for different source and apptype return values

The following functional areas are divided into two points
1. All middleware is selected by default
2. If apptype is set to custom, `htmlFallbackMiddleware` and `notFoundMiddleware` will not be used

if the appType is set to `spa`, but the user passes in multiple inputs at this time
```ts
import { defineConfig } from "@farmfe/core";
import path from "path";

export default defineConfig({
  compilation: {
    input: {
      index: path.resolve(__dirname, "index.html"),
      base: path.resolve(__dirname, 'base.html'),
      about: path.resolve(__dirname, 'about.html'),
    },
  },
  server: {
    appType: "mpa",
  },
});
```

Then the following paths are valid as

### if the appType is set to `spa`,

effective：
`localhost:3000`
`localhost:3000/`
`localhost:3000/123456`
`localhost:3000/index.html`
`localhost:3000/base.html`
`localhost:3000/about.html`

### if the appType is set to `mpa`

this `localhost:3000/123456` will be not effective return undefined

### if the appType is set to `custom`

```ts
    if (appType === 'spa' || appType === 'mpa') {
      this.middlewares.use(htmlFallbackMiddleware(this));

      this.middlewares.use(notFoundMiddleware());
    }
```

Then we will not control the situation where middlewareMode is currently only set to true in the user's functional scenario for returning html

Subsequent pr will analyze all scenarios and functions of each middleware in detail