### PR TITLE
fix: wrong esm introp helper order when using top level await

### DIFF
--- a/.changeset/good-pants-repair.md
+++ b/.changeset/good-pants-repair.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+fix #1499 wrong defaults of side effects of vite plugin adapter hook resolveId

--- a/.changeset/strong-scissors-reply.md
+++ b/.changeset/strong-scissors-reply.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+Fix wrong esm introp helper order when using top level await

--- a/crates/compiler/tests/fixtures/tree_shake/deep_dynamic_import/output.js
+++ b/crates/compiler/tests/fixtures/tree_shake/deep_dynamic_import/output.js
@@ -92,10 +92,10 @@
 }
 ,
 "b5d64806":async function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
     const [_f_main__f] = await Promise.all([
         farmRequire("7c4a34c2")
     ]);
-    module._m(exports);
     var _f_main = module.i(_f_main__f);
     console.log(module.f(_f_main));
 }

--- a/e2e/vitestSetup.ts
+++ b/e2e/vitestSetup.ts
@@ -6,7 +6,6 @@ import { execa } from 'execa';
 // export const browserLogs: string[] = [];
 // export const browserErrors: Error[] = [];
 export const concurrencyLimit = 50;
-export const pageMap = new Map<string, Page>();
 
 function getServerPort(): Promise<number> {
   return fetch('http://127.0.0.1:12306/port')
@@ -30,7 +29,7 @@ const visitPage = async (
 
   const browser = await chromium.connect(wsEndpoint);
   const page = await browser?.newPage();
-  page && pageMap.set(path, page);
+
   logger(`open the page: ${path} ${examplePath}`);
   try {
     page?.on('console', (msg) => {

--- a/examples/tree-shake-antd/e2e.spec.ts
+++ b/examples/tree-shake-antd/e2e.spec.ts
@@ -18,7 +18,7 @@ describe(`e2e tests - ${name}`, async () => {
 
         const button = await page.waitForSelector('.test-antd-button');
 
-        button.click();
+        await button.click();
         await promise;
       },
       command

--- a/packages/core/src/plugin/js/vite-plugin-adapter.ts
+++ b/packages/core/src/plugin/js/vite-plugin-adapter.ts
@@ -439,7 +439,7 @@ export class VitePluginAdapter implements JsPlugin {
             return {
               resolvedPath: removeQuery(encodeStr(resolveIdResult)),
               query: customParseQueryString(resolveIdResult),
-              sideEffects: false,
+              sideEffects: true,
               external: false,
               meta: {}
             };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
