### PR TITLE
Introducing Farm Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
     <img src="https://img.shields.io/npm/l/@farmfe/core?style=flat-square&colorA=ffe3f5&colorB=711a5f" alt="license" />
   </a>
   <a href="https://gurubase.io/g/farm">
-    <img src="https://img.shields.io/badge/Gurubase-Ask%20Farm%20Guru-006BFF" alt="Gurubase" />
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20Farm%20Guru-711a5f?style=flat-square&labelColor=ffe3f5" alt="Gurubase" />
   </a>
   </p>
   <br/>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@
   <a href="https://github.com/farm-fe/farm/blob/main/LICENSE">
     <img src="https://img.shields.io/npm/l/@farmfe/core?style=flat-square&colorA=ffe3f5&colorB=711a5f" alt="license" />
   </a>
+  <a href="https://gurubase.io/g/farm">
+    <img src="https://img.shields.io/badge/Gurubase-Ask%20Farm%20Guru-006BFF" alt="Gurubase" />
+  </a>
   </p>
   <br/>
 </div>


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Farm Guru](https://gurubase.io/g/farm) to Gurubase. Farm Guru uses the data from this repo and data from the [docs](https://farmfe.org) to answer questions by leveraging the LLM.

In this PR, I showcased the "Farm Guru", which highlights that Farm now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Farm Guru in Gurubase, just let me know that's totally fine.
