### PR TITLE
fix: short name display on windows

### DIFF
--- a/packages/core/src/utils/path.ts
+++ b/packages/core/src/utils/path.ts
@@ -24,7 +24,7 @@ export function removeHashFromPath(path: string): string {
 
 export function getShortName(file: string, root: string): string {
   const result = file.startsWith(withTrailingSlash(root))
-    ? path.posix.relative(root, file)
+    ? path.relative(root, file)
     : file;
   return result;
 }


### PR DESCRIPTION
The original code uses `path.posix.relative()` that specifics the platform to linux, use `path.relative` to automaically determine how to extract the relative path.

Resolved: #1859