### PR TITLE
fix: disable inline scripts

### DIFF
--- a/.changeset/hungry-bikes-guess.md
+++ b/.changeset/hungry-bikes-guess.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+fix: disable inline scripts

--- a/crates/plugin_html/src/resources_injector.rs
+++ b/crates/plugin_html/src/resources_injector.rs
@@ -106,7 +106,7 @@ impl<'a> ResourcesInjector<'a> {
     }
   }
 
-  fn inject_initial_loaded_resources(&self, element: &mut Element) {
+  fn inject_initial_loaded_resources(&mut self, element: &mut Element) {
     let mut initial_resources = vec![];
     initial_resources.extend(self.script_resources.clone());
     initial_resources.extend(self.css_resources.clone());
@@ -118,14 +118,33 @@ impl<'a> ResourcesInjector<'a> {
       .collect::<Vec<_>>()
       .join(",");
 
-    element.children.push(Child::Element(create_element(
-      "script",
-      Some(&format!(
-        r#"{}.{}.setInitialLoadedResources([{}]);"#,
-        self.farm_global_this, FARM_MODULE_SYSTEM, initial_resources_code
-      )),
-      vec![],
-    )));
+    let code = format!(
+      r#"{}.{}.setInitialLoadedResources([{}]);"#,
+      self.farm_global_this, FARM_MODULE_SYSTEM, initial_resources_code
+    );
+    if get_config_runtime_isolate(&self.options.context) {
+      let (name, resource) = create_farm_runtime_output_resource(
+        Cow::Owned(code.into_bytes()),
+        "initial_loaded_resources",
+        &self.options.context,
+        &self.already_injected_resources,
+      );
+      element.children.push(Child::Element(create_element(
+        "script",
+        None,
+        vec![("src", &format!("/{}", name))],
+      )));
+
+      if let Some(resource) = resource {
+        self.additional_inject_resources.push(resource);
+      }
+    } else {
+      element.children.push(Child::Element(create_element(
+        "script",
+        Some(&code),
+        vec![],
+      )));
+    }
   }
 
   fn inject_dynamic_resources_map(&mut self, element: &mut Element) {
@@ -167,7 +186,7 @@ impl<'a> ResourcesInjector<'a> {
     }
   }
 
-  fn inject_global_this(&self, element: &mut Element) {
+  fn inject_global_this(&mut self, element: &mut Element) {
     let code = format!(
       r#"
 {FARM_GLOBAL_THIS} = {{}};
@@ -177,11 +196,29 @@ impl<'a> ResourcesInjector<'a> {
       FARM_GLOBAL_THIS = self.farm_global_this,
     );
 
-    element.children.push(Child::Element(create_element(
-      "script",
-      Some(&code),
-      vec![],
-    )));
+    if get_config_runtime_isolate(&self.options.context) {
+      let (name, resource) = create_farm_runtime_output_resource(
+        Cow::Owned(code.into_bytes()),
+        "global_this",
+        &self.options.context,
+        &self.already_injected_resources,
+      );
+
+      element.children.push(Child::Element(create_element(
+        "script",
+        None,
+        vec![("src", &format!("/{name}"))],
+      )));
+      if let Some(resource) = resource {
+        self.additional_inject_resources.push(resource);
+      }
+    } else {
+      element.children.push(Child::Element(create_element(
+        "script",
+        Some(&code),
+        vec![],
+      )));
+    }
   }
 
   fn inject_other_entry_file(&self, element: &mut Element) {
@@ -236,7 +273,7 @@ impl<'a> ResourcesInjector<'a> {
       Cow::Owned(finalize_code.into_bytes()),
       FARM_MODULE_SYSTEM_RESOURCE,
       &self.options.context,
-      &self.already_injected_resources
+      &self.already_injected_resources,
     );
     // inject script
     element.children.push(Child::Element(create_element(

--- a/examples/react/farm.config.js
+++ b/examples/react/farm.config.js
@@ -1,32 +1,38 @@
-import { defineConfig } from '@farmfe/core';
-import react from '@farmfe/plugin-react';
+import { defineConfig } from "@farmfe/core";
+import react from "@farmfe/plugin-react";
 
 export default defineConfig((env) => {
   console.log(env);
   console.log(process.env.NODE_ENV);
-  
+
   return {
     compilation: {
       sourcemap: true,
       persistentCache: false,
       presetEnv: false,
       minify: false,
-      progress: false
+      progress: false,
       // output: {
       //   publicPath: '/dist/'
       // },
+      runtime: {
+        isolate: true,
+      },
     },
     server: {
       port: 4000,
       proxy: {
-        '^/(api|login|register|messages)': {
-          target: 'https://petstore.swagger.io/v2',
-          ws: true
+        "^/(api|login|register|messages)": {
+          target: "https://petstore.swagger.io/v2",
+          ws: true,
         },
-      }
+      },
     },
-    plugins: [react({
-      useAbsolutePath: true
-    }), '@farmfe/plugin-sass']
+    plugins: [
+      react({
+        useAbsolutePath: true,
+      }),
+      "@farmfe/plugin-sass",
+    ],
   };
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
if runtime.isolate was set to be true , `global_this` or `initial_loaded_resources` will set to be external  

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
None

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**
https://github.com/farm-fe/farm/issues/1803