### PR TITLE
chore: delete react template warning code

### DIFF
--- a/.changeset/forty-tips-jump.md
+++ b/.changeset/forty-tips-jump.md
@@ -1,0 +1,5 @@
+---
+"create-farm": patch
+---
+
+chore: delete react template warning code

--- a/crates/create-farm-rs/templates/react/src/index.tsx
+++ b/crates/create-farm-rs/templates/react/src/index.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { Main } from './main';
 import './index.css'
 
 
-const container = document.querySelector('#root');
+const container = document.querySelector('#root') as Element;
 const root = createRoot(container);
 
 root.render(<Main />);

--- a/crates/create-farm-rs/templates/react/src/main.tsx
+++ b/crates/create-farm-rs/templates/react/src/main.tsx
@@ -1,7 +1,7 @@
-import React, { useState } from "react";
-import "./main.css";
-import reactLogo from "./assets/react.svg";
-import FarmLogo from "./assets/logo.png";
+import { useState } from 'react';
+import './main.css';
+import reactLogo from './assets/react.svg';
+import FarmLogo from './assets/logo.png';
 export function Main() {
   const [count, setCount] = useState(0);
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:** after use the `pnpm create farm` create the react template, the template code has some warning.
![1](https://github.com/user-attachments/assets/574de4ad-5041-412c-97d4-39fa0bcc8bd8)
![2](https://github.com/user-attachments/assets/ae6d5909-48fa-44e0-900e-fe5746a7be89)


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:** no

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):** no
