### PR TITLE
fix(plugin_resolve): duplicated querystring on external

### DIFF
--- a/.changeset/tiny-berries-think.md
+++ b/.changeset/tiny-berries-think.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+Fix query strings in external imports are duplicated

--- a/crates/plugin_resolve/src/lib.rs
+++ b/crates/plugin_resolve/src/lib.rs
@@ -83,7 +83,7 @@ impl Plugin for FarmPluginResolve {
       // check external first, if the source is set as external, return it immediately
       if external_config.is_external(source) {
         return Ok(Some(PluginResolveHookResult {
-          resolved_path: param.source.clone(),
+          resolved_path: String::from(source),
           external: true,
           side_effects: false,
           query,


### PR DESCRIPTION
**Description:**
* When I externalize dependencies with querystring, the query duplicates.
* For example:
	* `import { Astal } from 'gi://Astal?version=4.0`
	* with externalizing `['^gi://']`
	* yields `import { o } from "gi://Astal?version=4.0?version=4.0";`


**Reproduction:**
<details>

```diff
diff --git a/farm.config.js b/farm.config.js
new file mode 100644
index 0000000..aaa84db
--- /dev/null
+++ b/farm.config.js
@@ -0,0 +1,9 @@
+import { defineConfig } from '@farmfe/core';
+
+export default defineConfig({
+	compilation: {
+		input: { index: './index.js' },
+		output: { targetEnv: 'library' },
+		external: ['^gi://']
+	},
+});
diff --git a/index.js b/index.js
new file mode 100644
index 0000000..0c019aa
--- /dev/null
+++ b/index.js
@@ -0,0 +1,2 @@
+import Astal from "gi://Astal?version=4.0";
+export { Astal };
diff --git a/package.json b/package.json
new file mode 100644
index 0000000..2061134
--- /dev/null
+++ b/package.json
@@ -0,0 +1,17 @@
+{
+  "name": "farm-minimal-external",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "farm build",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@farmfe/cli": "^1.0.4",
+    "@farmfe/core": "^1.6.4"
+  }
+}
```

</details>
