### PR TITLE
chore: refactor farm error handling

### DIFF
--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -238,6 +238,7 @@ export class Server extends httpServer {
       // this.logger.error(
       //   `Failed to create farm server: ${error}`
       // );
+      // TODO refactor format error
       throw error;
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

- 1. recovered_errors: 

![image](https://github.com/user-attachments/assets/0f244576-cf84-4922-a7e8-39d77b81ca6b)

Semantically unclear I don't think messages passed to users have comments like tags
If there is an unclear situation if the change word that will not continue to allow the user to restart the service even if the first compilation is started