### PR TITLE
Fix(template): Missing dev dependency react-refresh on TauriJS

### DIFF
--- a/.changeset/grumpy-socks-travel.md
+++ b/.changeset/grumpy-socks-travel.md
@@ -1,0 +1,5 @@
+---
+"create-farm": patch
+---
+
+Add missing react-refresh dev dependency on TauriJS templates.

--- a/crates/create-farm-rs/templates/tauri2/preact/package.json
+++ b/crates/create-farm-rs/templates/tauri2/preact/package.json
@@ -19,6 +19,7 @@
     "@farmfe/core": "^1.6.3",
     "@preact/preset-vite": "^2.9.3",
     "core-js": "^3.39.0",
+    "react-refresh": "^0.16.0",
     "typescript": "^5.6.2",
     "@tauri-apps/cli": "^2"
   }

--- a/crates/create-farm-rs/templates/tauri2/react/package.json
+++ b/crates/create-farm-rs/templates/tauri2/react/package.json
@@ -23,6 +23,7 @@
     "@types/react": "^18.3.18",
     "@types/react-dom": "^18.3.5",
     "core-js": "^3.39.0",
+    "react-refresh": "^0.16.0",
     "typescript": "^5.7.2"
   }
 }

--- a/crates/create-farm-rs/templates/tauri2/solid/package.json
+++ b/crates/create-farm-rs/templates/tauri2/solid/package.json
@@ -20,6 +20,7 @@
     "@farmfe/cli": "^1.0.4",
     "@farmfe/core": "^1.6.3",
     "core-js": "^3.39.0",
+    "react-refresh": "^0.16.0",
     "typescript": "~5.6.2",
     "vite-plugin-solid": "^2.11.0",
     "@tauri-apps/cli": "^2"

--- a/crates/create-farm-rs/templates/tauri2/svelte/package.json
+++ b/crates/create-farm-rs/templates/tauri2/svelte/package.json
@@ -25,6 +25,7 @@
     "svelte": "^5.0.0",
     "svelte-check": "^4.0.0",
     "core-js": "^3.39.0",
+    "react-refresh": "^0.16.0",
     "typescript": "~5.6.2",
     "@tauri-apps/cli": "^2"
   }

--- a/crates/create-farm-rs/templates/tauri2/vue/package.json
+++ b/crates/create-farm-rs/templates/tauri2/vue/package.json
@@ -20,6 +20,7 @@
     "@tauri-apps/cli": "^2.1.0",
     "@vitejs/plugin-vue": "^5.2.1",
     "core-js": "^3.39.0",
+    "react-refresh": "^0.16.0",
     "typescript": "^5.7.2",
     "vue-tsc": "^2.2.0"
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

When generating a TauriJS project, installing its dependencies and running it with the command `npm/pnpm/bun/etc run tauri dev` the development dependency react-refresh jumps with an error because it is not referenced in the project and consequently in the package.json of the template when generating the project. This PR adds that dependency to all TauriJS related templates to eliminate the error.

![image](https://github.com/user-attachments/assets/29b78877-0fe2-40a5-9141-d8f1c79dd38b)


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
