### PR TITLE
fix: assign reference treeshake

### DIFF
--- a/.changeset/eight-fans-report.md
+++ b/.changeset/eight-fans-report.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+fix treeshake assign expr reference

--- a/.changeset/kind-cycles-bake.md
+++ b/.changeset/kind-cycles-bake.md
@@ -1,0 +1,5 @@
+---
+"create-farm": patch
+---
+
+lock vue template @vitejs/plugin-vue version

--- a/crates/compiler/tests/common/mod.rs
+++ b/crates/compiler/tests/common/mod.rs
@@ -190,6 +190,7 @@ pub fn create_compiler(
         ConfigRegex::new("^react-refresh$"),
         ConfigRegex::new("^module$"),
         ConfigRegex::new("^vue$"),
+        ConfigRegex::new("^fake-module$"),
       ],
       sourcemap: Box::new(SourcemapConfig::Bool(false)),
       lazy_compilation: false,

--- a/crates/compiler/tests/fixtures/tree_shake/issue_2133/array_assign.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/issue_2133/array_assign.ts
@@ -1,0 +1,24 @@
+// @ts-ignore
+import { target1, target as target3, target2 } from "fake-module";
+
+// reference
+var _a1;
+[_a1] = [target3], _a1.namespace = 234;
+
+// no write operation, should be deleted
+var _a2;
+[_a2] = [target3];
+
+// no reference
+var _b1;
+[_b1] = [target2], _b1.namespace = 234;
+
+target1.namespace = 234;
+
+var arrayAssign = new Proxy(target3.__VUE_DEVTOOLS_KIT_TIMELINE_LAYERS, {
+  get(target22, prop, receiver) {
+    return Reflect.get(target22, prop, receiver);
+  }
+});
+
+console.log({ arrayAssign })

--- a/crates/compiler/tests/fixtures/tree_shake/issue_2133/index.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/issue_2133/index.ts
@@ -1,0 +1,2 @@
+import './array_assign';
+import './single_assign';

--- a/crates/compiler/tests/fixtures/tree_shake/issue_2133/output.js
+++ b/crates/compiler/tests/fixtures/tree_shake/issue_2133/output.js
@@ -1,0 +1,105 @@
+//index.js:
+ window['__farm_default_namespace__'] = {__FARM_TARGET_ENV__: 'browser'};function _interop_require_default(obj) {
+    return obj && obj.__esModule ? obj : {
+        default: obj
+    };
+}function _export_star(from, to) {
+    Object.keys(from).forEach(function(k) {
+        if (k !== "default" && !Object.prototype.hasOwnProperty.call(to, k)) {
+            Object.defineProperty(to, k, {
+                enumerable: true,
+                get: function() {
+                    return from[k];
+                }
+            });
+        }
+    });
+    return from;
+}function _interop_require_wildcard(obj, nodeInterop) {
+    if (!nodeInterop && obj && obj.__esModule) return obj;
+    if (obj === null || typeof obj !== "object" && typeof obj !== "function") return {
+        default: obj
+    };
+    var cache = _getRequireWildcardCache(nodeInterop);
+    if (cache && cache.has(obj)) return cache.get(obj);
+    var newObj = {
+        __proto__: null
+    };
+    var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
+    for(var key in obj){
+        if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
+            var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null;
+            if (desc && (desc.get || desc.set)) Object.defineProperty(newObj, key, desc);
+            else newObj[key] = obj[key];
+        }
+    }
+    newObj.default = obj;
+    if (cache) cache.set(obj, newObj);
+    return newObj;
+}function _getRequireWildcardCache(nodeInterop) {
+    if (typeof WeakMap !== "function") return null;
+    var cacheBabelInterop = new WeakMap();
+    var cacheNodeInterop = new WeakMap();
+    return (_getRequireWildcardCache = function(nodeInterop) {
+        return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
+    })(nodeInterop);
+}function __commonJs(mod) {
+  var module;
+  return () => {
+    if (module) {
+      return module.exports;
+    }
+    module = {
+      exports: {},
+    };
+    if(typeof mod === "function") {
+      mod(module, module.exports);
+    }else {
+      mod[Object.keys(mod)[0]](module, module.exports);
+    }
+    return module.exports;
+  };
+}((function(){var index_js_cjs = __commonJs((module, exports)=>{
+    "use strict";
+    console.log('runtime/index.js');
+    window['__farm_default_namespace__'].__farm_module_system__.setPlugins([]);
+});
+index_js_cjs();
+})());window['__farm_default_namespace__'].__farm_module_system__.setExternalModules({"fake-module": (window['fake-module']||{}).default && !(window['fake-module']||{}).__esModule ? {...(window['fake-module']||{}),__esModule:true} : window['fake-module']||{}});(function(_){var filename = ((function(){var _documentCurrentScript = typeof document !== "undefined" ? document.currentScript : null;return typeof document === "undefined" ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && _documentCurrentScript.src || new URL("index_dfc5.js", document.baseURI).href})());for(var r in _){_[r].__farm_resource_pot__=filename;window['__farm_default_namespace__'].__farm_module_system__.register(r,_[r])}})({"b5d64806":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    farmRequire("e3e06d35");
+    farmRequire("fe72c3ec");
+}
+,
+"e3e06d35":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    var _f_fake_module = farmRequire("fake-module");
+    var _a1;
+    [_a1] = [
+        _f_fake_module.target
+    ], _a1.namespace = 234;
+    var arrayAssign = new Proxy(_f_fake_module.target.__VUE_DEVTOOLS_KIT_TIMELINE_LAYERS, {
+        get (target22, prop, receiver) {
+            return Reflect.get(target22, prop, receiver);
+        }
+    });
+    console.log({
+        arrayAssign
+    });
+}
+,
+"fe72c3ec":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    var _f_fake_module = farmRequire("fake-module");
+    var _a1, _a2;
+    (_a2 = (_a1 = _f_fake_module.target).__VUE_DEVTOOLS_KIT_TIMELINE_LAYERS) != null ? _a2 : _a1.__VUE_DEVTOOLS_KIT_TIMELINE_LAYERS = [];
+    var singleAssign = new Proxy(_f_fake_module.target.__VUE_DEVTOOLS_KIT_TIMELINE_LAYERS, {
+        get (target22, prop, receiver) {
+            return Reflect.get(target22, prop, receiver);
+        }
+    });
+    console.log({
+        singleAssign
+    });
+}
+,});window['__farm_default_namespace__'].__farm_module_system__.setInitialLoadedResources([]);window['__farm_default_namespace__'].__farm_module_system__.setDynamicModuleResourcesMap([],{  });var farmModuleSystem = window['__farm_default_namespace__'].__farm_module_system__;farmModuleSystem.bootstrap();var entry = farmModuleSystem.require("b5d64806");

--- a/crates/compiler/tests/fixtures/tree_shake/issue_2133/single_assign.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/issue_2133/single_assign.ts
@@ -1,0 +1,20 @@
+// @ts-ignore
+import { target1, target as target2, target3 } from "fake-module";
+
+// reference
+var _a1, _a2;
+(_a2 = (_a1 = target2).__VUE_DEVTOOLS_KIT_TIMELINE_LAYERS) != null ? _a2 : _a1.__VUE_DEVTOOLS_KIT_TIMELINE_LAYERS = [];
+
+// no reference
+var _b1, _b2;
+(_b2 = (_b1 = target1).__VUE_DEVTOOLS_KIT_TIMELINE_LAYERS) != null ? _b2 : _b1.__VUE_DEVTOOLS_KIT_TIMELINE_LAYERS = [];
+
+target3.namespace = 234;
+
+var singleAssign = new Proxy(target2.__VUE_DEVTOOLS_KIT_TIMELINE_LAYERS, {
+  get(target22, prop, receiver) {
+    return Reflect.get(target22, prop, receiver);
+  }
+});
+
+console.log({ singleAssign })

--- a/crates/create-farm-rs/templates/electron/vue/package.json
+++ b/crates/create-farm-rs/templates/electron/vue/package.json
@@ -25,7 +25,7 @@
     "core-js": "^3.36.1",
     "electron": "^30.0.9",
     "fs-extra": "^11.2.0",
-    "@vitejs/plugin-vue": "^5.0.4",
+    "@vitejs/plugin-vue": "5.0.4",
     "typescript": "^5.0.2",
     "vue-tsc": "^1.8.5"
   }

--- a/crates/create-farm-rs/templates/tauri/vue/package.json
+++ b/crates/create-farm-rs/templates/tauri/vue/package.json
@@ -14,7 +14,7 @@
     "@tauri-apps/api": "^1"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^5.0.4",
+    "@vitejs/plugin-vue": "5.0.4",
     "typescript": "^5.0.2",
     "vue-tsc": "^1.8.5",
     "@tauri-apps/cli": "^1",

--- a/crates/create-farm-rs/templates/tauri2/vue/package.json
+++ b/crates/create-farm-rs/templates/tauri2/vue/package.json
@@ -18,7 +18,7 @@
     "@farmfe/cli": "^1.0.4",
     "@farmfe/core": "^1.6.7",
     "@tauri-apps/cli": "^2.1.0",
-    "@vitejs/plugin-vue": "^5.2.1",
+    "@vitejs/plugin-vue": "5.0.4",
     "core-js": "^3.39.0",
     "typescript": "^5.7.2",
     "vue-tsc": "^2.2.0"

--- a/crates/create-farm-rs/templates/vue3/package.json
+++ b/crates/create-farm-rs/templates/vue3/package.json
@@ -14,7 +14,7 @@
   "devDependencies": {
     "@farmfe/cli": "^1.0.4",
     "@farmfe/core": "^1.6.7",
-    "@vitejs/plugin-vue": "^5.0.4",
+    "@vitejs/plugin-vue": "5.0.4",
     "core-js": "^3.30.1"
   }
 }

--- a/crates/plugin_tree_shake/src/lib.rs
+++ b/crates/plugin_tree_shake/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(box_patterns)]
 #![feature(exact_size_is_empty)]
+#![feature(let_chains)]
 
 use farmfe_core::{
   config::{Config, Mode},

--- a/crates/plugin_tree_shake/src/statement_graph/analyze_deps_by_used_idents.rs
+++ b/crates/plugin_tree_shake/src/statement_graph/analyze_deps_by_used_idents.rs
@@ -6,6 +6,7 @@ use farmfe_toolkit::swc_ecma_visit::{Visit, VisitWith};
 use super::{defined_idents_collector::DefinedIdentsCollector, StatementGraphEdge, StatementId};
 
 pub struct AnalyzeUsedIdentsParams<'a> {
+  #[allow(dead_code)]
   pub id: &'a StatementId,
   pub stmt: &'a ModuleItem,
   pub reverse_defined_idents_map: &'a HashMap<Id, StatementId>,

--- a/crates/plugin_tree_shake/src/statement_graph/analyze_statement_side_effects.rs
+++ b/crates/plugin_tree_shake/src/statement_graph/analyze_statement_side_effects.rs
@@ -77,7 +77,7 @@ struct LeftIdentReference {
   /// a = target, a.namespace = [1, 2, 3]
   ///             ^           ^
   /// ```
-  mark_writed: bool,
+  mark_write: bool,
 }
 
 impl LeftIdentReference {
@@ -156,7 +156,7 @@ impl<'a> SideEffectsAnalyzer<'a> {
     visitor.visit_children_with(self);
 
     for (_, rights) in mem::take(&mut self.assign_left_reference) {
-      if !rights.mark_writed {
+      if !rights.mark_write {
         continue;
       }
       self
@@ -321,7 +321,7 @@ impl<'a> Visit for SideEffectsAnalyzer<'a> {
         if let Some(ref mut left) = self.in_assign_left {
           left.insert(ident.to_id());
           if let Some(v) = self.assign_left_reference.get_mut(&ident.to_id()) {
-            v.mark_writed = true;
+            v.mark_write = true;
           }
         }
 

--- a/crates/plugin_tree_shake/src/statement_graph/analyze_statement_side_effects.rs
+++ b/crates/plugin_tree_shake/src/statement_graph/analyze_statement_side_effects.rs
@@ -1,13 +1,19 @@
-use std::collections::HashSet;
+use std::{
+  collections::{HashMap, HashSet},
+  mem,
+};
 
 use farmfe_core::{
   swc_common::{
     comments::{Comments, SingleThreadedComments},
     Mark, Spanned,
   },
-  swc_ecma_ast::{Expr, ModuleItem},
+  swc_ecma_ast::{Expr, Id, ModuleItem},
 };
-use farmfe_toolkit::swc_ecma_visit::{Visit, VisitWith};
+use farmfe_toolkit::{
+  swc_ecma_utils::ident::IdentLike,
+  swc_ecma_visit::{Visit, VisitWith},
+};
 
 use super::StatementSideEffects;
 
@@ -26,7 +32,7 @@ pub fn analyze_statement_side_effects(
         farmfe_core::swc_ecma_ast::Decl::Var(var_decl) => {
           let mut analyzer = SideEffectsAnalyzer::new(unresolved_mark, top_level_mark, comments);
           analyzer.set_in_top_level(true);
-          var_decl.visit_children_with(&mut analyzer);
+          analyzer.analyze(var_decl);
 
           analyzer.side_effects
         }
@@ -39,7 +45,7 @@ pub fn analyze_statement_side_effects(
       farmfe_core::swc_ecma_ast::ModuleDecl::ExportDefaultExpr(default_expr) => {
         let mut analyzer = SideEffectsAnalyzer::new(unresolved_mark, top_level_mark, comments);
         analyzer.set_in_top_level(true);
-        default_expr.expr.visit_with(&mut analyzer);
+        analyzer.analyze(default_expr.expr.as_ref());
         analyzer.side_effects
       }
       farmfe_core::swc_ecma_ast::ModuleDecl::ExportAll(_) => StatementSideEffects::NoSideEffects,
@@ -48,10 +54,41 @@ pub fn analyze_statement_side_effects(
     ModuleItem::Stmt(stmt) => {
       let mut analyzer = SideEffectsAnalyzer::new(unresolved_mark, top_level_mark, comments);
       analyzer.set_in_top_level(true);
-      stmt.visit_with(&mut analyzer);
+      analyzer.analyze(stmt);
 
       analyzer.side_effects
     }
+  }
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct LeftIdentReference {
+  ///
+  /// ```unknown
+  /// [a, b, c] = [target1, target2, target3]
+  ///              ^^^^^^^  ^^^^^^^  ^^^^^^^
+  /// ```
+  ///
+  idents: HashSet<Id>,
+  ///
+  /// mark write operation
+  ///
+  /// ```unknown
+  /// a = target, a.namespace = [1, 2, 3]
+  ///             ^           ^
+  /// ```
+  mark_writed: bool,
+}
+
+impl LeftIdentReference {
+  fn insert(&mut self, id: Id) {
+    self.idents.insert(id);
+  }
+}
+
+impl From<LeftIdentReference> for HashSet<Id> {
+  fn from(value: LeftIdentReference) -> Self {
+    value.idents
   }
 }
 
@@ -61,9 +98,24 @@ struct SideEffectsAnalyzer<'a> {
   side_effects: StatementSideEffects,
   comments: &'a SingleThreadedComments,
 
-  in_assign_left: bool,
+  in_assign_left: Option<HashSet<Id>>,
+  in_assign_right: Option<Option<HashSet<Id>>>,
   in_top_level: bool,
   in_call: bool,
+
+  ///
+  /// ```unknown
+  /// a = target, a.namespace = [1, 2, 3]
+  /// ^   ^^^^^^
+  /// ```
+  ///
+  /// ```js
+  /// {
+  ///  a: [target]
+  /// }
+  /// ```
+  ///
+  assign_left_reference: HashMap<Id, LeftIdentReference>,
 }
 
 impl<'a> SideEffectsAnalyzer<'a> {
@@ -77,9 +129,11 @@ impl<'a> SideEffectsAnalyzer<'a> {
       top_level_mark,
       side_effects: StatementSideEffects::NoSideEffects,
       comments,
-      in_assign_left: false,
+      in_assign_left: None,
       in_top_level: false,
       in_call: false,
+      in_assign_right: None,
+      assign_left_reference: HashMap::new(),
     }
   }
 
@@ -89,6 +143,26 @@ impl<'a> SideEffectsAnalyzer<'a> {
 
   pub fn is_in_top_level(&self) -> bool {
     self.in_top_level
+  }
+
+  pub fn with_assign_right<F: FnOnce(&mut Self)>(&mut self, id: Option<HashSet<Id>>, f: F) {
+    let prev = self.in_assign_right.take();
+    self.in_assign_right = Some(id);
+    f(self);
+    self.in_assign_right = prev;
+  }
+
+  pub fn analyze<F: VisitWith<Self>>(&mut self, visitor: &F) {
+    visitor.visit_children_with(self);
+
+    for (_, rights) in mem::take(&mut self.assign_left_reference) {
+      if !rights.mark_writed {
+        continue;
+      }
+      self
+        .side_effects
+        .merge_side_effects(StatementSideEffects::WriteTopLevelVar(rights.into()));
+    }
   }
 }
 
@@ -103,6 +177,15 @@ impl<'a> Visit for SideEffectsAnalyzer<'a> {
   }
 
   fn visit_function(&mut self, n: &farmfe_core::swc_ecma_ast::Function) {
+    let pre = self.is_in_top_level();
+    self.set_in_top_level(false);
+
+    n.visit_children_with(self);
+
+    self.set_in_top_level(pre);
+  }
+
+  fn visit_class(&mut self, n: &farmfe_core::swc_ecma_ast::Class) {
     let pre = self.is_in_top_level();
     self.set_in_top_level(false);
 
@@ -204,6 +287,12 @@ impl<'a> Visit for SideEffectsAnalyzer<'a> {
     }
   }
 
+  fn visit_ident(&mut self, ident: &farmfe_core::swc_ecma_ast::Ident) {
+    if let Some(ref mut left) = self.in_assign_left {
+      left.insert(ident.to_id());
+    }
+  }
+
   fn visit_expr(&mut self, expr: &Expr) {
     if !self.is_in_top_level() {
       return;
@@ -229,9 +318,16 @@ impl<'a> Visit for SideEffectsAnalyzer<'a> {
         self.in_call = false;
       }
       Expr::Ident(ident) => {
+        if let Some(ref mut left) = self.in_assign_left {
+          left.insert(ident.to_id());
+          if let Some(v) = self.assign_left_reference.get_mut(&ident.to_id()) {
+            v.mark_writed = true;
+          }
+        }
+
         self
           .side_effects
-          .merge_side_effects(if self.in_assign_left {
+          .merge_side_effects(if self.in_assign_left.is_some() {
             if ident.span.ctxt().outer() == self.unresolved_mark {
               StatementSideEffects::WriteOrCallGlobalVar
             } else if self.in_top_level || ident.span.ctxt().outer() == self.top_level_mark {
@@ -246,13 +342,29 @@ impl<'a> Visit for SideEffectsAnalyzer<'a> {
           } else {
             StatementSideEffects::NoSideEffects
           });
+
+        if let Some(Some(ref lefts)) = self.in_assign_right
+          && (self.in_top_level || ident.span.ctxt().outer() == self.top_level_mark)
+        {
+          for left in lefts {
+            self
+              .assign_left_reference
+              .entry(left.to_id())
+              .or_default()
+              .insert(ident.to_id());
+          }
+        }
       }
       Expr::Assign(assign_expr) => {
-        self.in_assign_left = true;
+        self.in_assign_left = Some(HashSet::new());
 
         match &assign_expr.left {
           farmfe_core::swc_ecma_ast::AssignTarget::Simple(st) => match st {
             farmfe_core::swc_ecma_ast::SimpleAssignTarget::Ident(i) => {
+              self
+                .in_assign_left
+                .get_or_insert_with(HashSet::new)
+                .insert(i.id.to_id());
               // for idents that are added by ast transform, the mark may not be top_level_mark
               // in this case, we treat it as top level as long as current assign expr is in top level
               if self.in_top_level || i.id.span.ctxt.outer() == self.top_level_mark {
@@ -295,9 +407,12 @@ impl<'a> Visit for SideEffectsAnalyzer<'a> {
             pat.visit_with(self);
           }
         }
-        self.in_assign_left = false;
 
-        assign_expr.right.visit_with(self);
+        let left_ident = self.in_assign_left.take();
+
+        self.with_assign_right(left_ident, |this| {
+          assign_expr.right.visit_with(this);
+        });
       }
       Expr::Array(_)
       | Expr::Object(_)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

```js
// write
a = target, a.namespace = [1, 2, 3]
//          ^           ^
// use
console.log(target)
```

Writes to target should be recognized, so when target is used, write should be preserved

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**

fix #2133


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced the browser module system with dynamic module loading and improved reactive support.
	- Expanded module configuration to recognize a broader set of module patterns, including a new "fake-module".
	- Introduced a new configuration flag enabling concise variable binding.
	- Added new TypeScript files for handling variable assignments and Proxy objects.
	- Updated dependency specifications for the `@vitejs/plugin-vue` package to fixed versions across multiple templates.

- **Refactor**
	- Optimized the analysis of module side effects for better performance and state management.

- **Tests**
	- Added new test fixtures to validate module handling and assignment behaviors.

- **Chores**
	- Documented a patch addressing an issue with the treeshake functionality in the `@farmfe/core` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->