### PR TITLE
fix(dts): fix `@farmfe/js-plugin-dts` doesn't emit `d.ts` files

### DIFF
--- a/.changeset/slimy-banks-press.md
+++ b/.changeset/slimy-banks-press.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/js-plugin-dts": patch
+---
+
+fix dts file creation

--- a/js-plugins/dts/src/context.ts
+++ b/js-plugins/dts/src/context.ts
@@ -159,7 +159,10 @@ export default class Context {
           .getEmitOutput(sourceFile, true)
           .getOutputFiles()
           .filter((outputFile) => {
-            const outputPath = outputFile.compilerObject.name.replace(/\\/g, '/');
+            const outputPath = outputFile.compilerObject.name.replace(
+              /\\/g,
+              '/'
+            );
             const rootPath = this.options.root.replace(/\\/g, '/');
 
             return outputPath.startsWith(rootPath);

--- a/js-plugins/dts/src/context.ts
+++ b/js-plugins/dts/src/context.ts
@@ -158,9 +158,12 @@ export default class Context {
         service
           .getEmitOutput(sourceFile, true)
           .getOutputFiles()
-          .filter((outputFile) =>
-            outputFile.compilerObject.name.startsWith(this.options.root)
-          )
+          .filter((outputFile) => {
+            const outputPath = outputFile.compilerObject.name.replace(/\\/g, '/');
+            const rootPath = this.options.root.replace(/\\/g, '/');
+
+            return outputPath.startsWith(rootPath);
+          })
           .map((outputFile) => ({
             path: resolve(
               this.options.root,


### PR DESCRIPTION
**Description:**
- fix the bug that `@farmfe/js-plugin-dts` doesn't create `d.ts` files in Windows

![Image](https://github.com/user-attachments/assets/6ca33278-97d5-4e65-97ab-288808939e3a)
- [src/context.ts#L161-L163](https://github.com/Su-Yong/farm/blob/main/js-plugins/dts/src/context.ts#L161-L163)

![Image](https://github.com/user-attachments/assets/ba5ddfc6-a532-4a4a-a59e-a761057d9ae6)
- The result



**Related issue (if exists):**
- #2145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced file output handling for improved consistency and compatibility across different operating systems.
  
- **Bug Fixes**
  - Addressed issues related to the generation of TypeScript definition (dts) files in the `@farmfe/js-plugin-dts` package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->