### PR TITLE
fix: cjs node export order

### DIFF
--- a/.changeset/loud-hairs-bow.md
+++ b/.changeset/loud-hairs-bow.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+fix cjs node export sort

--- a/crates/compiler/tests/fixtures/script/cjs_export/config.json
+++ b/crates/compiler/tests/fixtures/script/cjs_export/config.json
@@ -1,0 +1,6 @@
+{
+  "output": {
+    "format": "cjs",
+    "targetEnv": "node"
+  }
+}

--- a/crates/compiler/tests/fixtures/script/cjs_export/index.ts
+++ b/crates/compiler/tests/fixtures/script/cjs_export/index.ts
@@ -1,0 +1,2 @@
+export const named = 'named';
+export default function foo() {}

--- a/crates/compiler/tests/fixtures/script/cjs_export/output.js
+++ b/crates/compiler/tests/fixtures/script/cjs_export/output.js
@@ -1,0 +1,79 @@
+//index.js:
+ global.nodeRequire = require;global['__farm_default_namespace__'] = {__FARM_TARGET_ENV__: 'node'};function _interop_require_default(obj) {
+    return obj && obj.__esModule ? obj : {
+        default: obj
+    };
+}function _export_star(from, to) {
+    Object.keys(from).forEach(function(k) {
+        if (k !== "default" && !Object.prototype.hasOwnProperty.call(to, k)) {
+            Object.defineProperty(to, k, {
+                enumerable: true,
+                get: function() {
+                    return from[k];
+                }
+            });
+        }
+    });
+    return from;
+}function _interop_require_wildcard(obj, nodeInterop) {
+    if (!nodeInterop && obj && obj.__esModule) return obj;
+    if (obj === null || typeof obj !== "object" && typeof obj !== "function") return {
+        default: obj
+    };
+    var cache = _getRequireWildcardCache(nodeInterop);
+    if (cache && cache.has(obj)) return cache.get(obj);
+    var newObj = {
+        __proto__: null
+    };
+    var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
+    for(var key in obj){
+        if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
+            var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null;
+            if (desc && (desc.get || desc.set)) Object.defineProperty(newObj, key, desc);
+            else newObj[key] = obj[key];
+        }
+    }
+    newObj.default = obj;
+    if (cache) cache.set(obj, newObj);
+    return newObj;
+}function _getRequireWildcardCache(nodeInterop) {
+    if (typeof WeakMap !== "function") return null;
+    var cacheBabelInterop = new WeakMap();
+    var cacheNodeInterop = new WeakMap();
+    return (_getRequireWildcardCache = function(nodeInterop) {
+        return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
+    })(nodeInterop);
+}function __commonJs(mod) {
+  var module;
+  return () => {
+    if (module) {
+      return module.exports;
+    }
+    module = {
+      exports: {},
+    };
+    if(typeof mod === "function") {
+      mod(module, module.exports);
+    }else {
+      mod[Object.keys(mod)[0]](module, module.exports);
+    }
+    return module.exports;
+  };
+}var index_js_cjs = __commonJs((module, exports)=>{
+    "use strict";
+    console.log('runtime/index.js');
+    global['__farm_default_namespace__'].__farm_module_system__.setPlugins([]);
+});
+index_js_cjs();
+(function(_){var filename = ((function(){var _documentCurrentScript = typeof document !== "undefined" ? document.currentScript : null;return typeof document === "undefined" ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && _documentCurrentScript.src || new URL("index_dcdc.js", document.baseURI).href})());for(var r in _){_[r].__farm_resource_pot__=filename;global['__farm_default_namespace__'].__farm_module_system__.register(r,_[r])}})({"b5d64806":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    module.o(exports, "named", function() {
+        return named;
+    });
+    module.o(exports, "default", function() {
+        return foo;
+    });
+    var named = 'named';
+    function foo() {}
+}
+,});global['__farm_default_namespace__'].__farm_module_system__.setInitialLoadedResources([]);global['__farm_default_namespace__'].__farm_module_system__.setDynamicModuleResourcesMap([],{  });var farmModuleSystem = global['__farm_default_namespace__'].__farm_module_system__;farmModuleSystem.bootstrap();var entry = farmModuleSystem.require("b5d64806");module.exports = entry.default || entry;module.exports.named = entry.named;

--- a/crates/compiler/tests/fixtures/tree_shake/empty_specifier_export_all/output.js
+++ b/crates/compiler/tests/fixtures/tree_shake/empty_specifier_export_all/output.js
@@ -90,4 +90,4 @@ index_js_cjs();
     var b = '2';
     console.log(a, b);
 }
-,});window['__farm_default_namespace__'].__farm_module_system__.setInitialLoadedResources([]);window['__farm_default_namespace__'].__farm_module_system__.setDynamicModuleResourcesMap([],{  });var farmModuleSystem = window['__farm_default_namespace__'].__farm_module_system__;farmModuleSystem.bootstrap();var entry = farmModuleSystem.require("b5d64806");var a=entry.a;export { a };var b=entry.b;export { b };export default entry.default || entry;
+,});window['__farm_default_namespace__'].__farm_module_system__.setInitialLoadedResources([]);window['__farm_default_namespace__'].__farm_module_system__.setDynamicModuleResourcesMap([],{  });var farmModuleSystem = window['__farm_default_namespace__'].__farm_module_system__;farmModuleSystem.bootstrap();var entry = farmModuleSystem.require("b5d64806");export default entry.default || entry;var a=entry.a;export { a };var b=entry.b;export { b };

--- a/packages/core/tests/__snapshots__/cjs.spec.ts.snap
+++ b/packages/core/tests/__snapshots__/cjs.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`resolveUserConfig > resolveUserConfig 1`] = `
   "$__farm_regex:(global(This)?\\.)?process\\.env\\.mode": ""development"",
   "FARM_HMR_HOST": "true",
   "FARM_HMR_PATH": ""/__hmr"",
-  "FARM_HMR_PORT": "9000",
+  "FARM_HMR_PORT": "9001",
   "FARM_HMR_PROTOCOL": """",
   "FARM_PROCESS_ENV": {
     "NODE_ENV": "development",

--- a/packages/core/tests/__snapshots__/cjs.spec.ts.snap
+++ b/packages/core/tests/__snapshots__/cjs.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`resolveUserConfig > resolveUserConfig 1`] = `
   "$__farm_regex:(global(This)?\\.)?process\\.env\\.mode": ""development"",
   "FARM_HMR_HOST": "true",
   "FARM_HMR_PATH": ""/__hmr"",
-  "FARM_HMR_PORT": "9001",
+  "FARM_HMR_PORT": "9000",
   "FARM_HMR_PROTOCOL": """",
   "FARM_PROCESS_ENV": {
     "NODE_ENV": "development",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option to tailor module output for Node environments using CommonJS.
  - Added enhanced module exports for improved interoperability.
  - Added a new variant to represent default exports in the export information system.

- **Bug Fixes**
  - Corrected the export ordering in CommonJS outputs to ensure default exports are prioritized over named exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->