### PR TITLE
feat: resolver by resolve kind

### DIFF
--- a/.changeset/silly-seals-cheat.md
+++ b/.changeset/silly-seals-cheat.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+resolver by resolve kind

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -227,7 +227,7 @@ pub struct ScriptParserConfig {
 #[serde(rename_all = "camelCase", default)]
 pub struct ResolveConfig {
   pub alias: HashMap<String, String>,
-  pub main_fields: Option<Vec<String>>,
+  pub main_fields: Vec<String>,
   pub main_files: Vec<String>,
   pub extensions: Vec<String>,
   pub conditions: Vec<String>,
@@ -240,7 +240,7 @@ impl Default for ResolveConfig {
   fn default() -> Self {
     Self {
       alias: HashMap::new(),
-      main_fields: None,
+      main_fields: vec![],
       main_files: vec![String::from("index")],
       extensions: vec![
         String::from("tsx"),

--- a/crates/core/src/config/mod.rs
+++ b/crates/core/src/config/mod.rs
@@ -227,7 +227,7 @@ pub struct ScriptParserConfig {
 #[serde(rename_all = "camelCase", default)]
 pub struct ResolveConfig {
   pub alias: HashMap<String, String>,
-  pub main_fields: Vec<String>,
+  pub main_fields: Option<Vec<String>>,
   pub main_files: Vec<String>,
   pub extensions: Vec<String>,
   pub conditions: Vec<String>,
@@ -240,13 +240,7 @@ impl Default for ResolveConfig {
   fn default() -> Self {
     Self {
       alias: HashMap::new(),
-      main_fields: vec![
-        String::from("browser"),
-        String::from("module"),
-        String::from("main"),
-        String::from("jsnext:main"),
-        String::from("jsnext"),
-      ],
+      main_fields: None,
       main_files: vec![String::from("index")],
       extensions: vec![
         String::from("tsx"),

--- a/crates/plugin_resolve/src/resolver.rs
+++ b/crates/plugin_resolve/src/resolver.rs
@@ -42,7 +42,7 @@ pub struct ResolveCacheKey {
   pub base_dir: String,
   pub kind: ResolveKind,
   pub options: ResolveOptions,
-  pub main_fields: Option<Vec<String>>,
+  pub main_fields: Vec<String>,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
@@ -728,15 +728,14 @@ impl Resolver {
         .map(|exports_entries| exports_entries.get(0).unwrap().to_string())
       })
       .or_else(|| {
-        let main_fields = if let Some(ref main_fields) = context.config.resolve.main_fields {
-          Some(Cow::Borrowed(main_fields))
+        let main_fields = if !context.config.resolve.main_fields.is_empty() {
+          Some(Cow::Borrowed(&context.config.resolve.main_fields))
         } else {
           let main_fields_from_resolve_kind = match kind {
             ResolveKind::Require => Some(vec!["main".to_string()]),
             ResolveKind::Import => Some(vec!["module".to_string()]),
             _ => None,
           };
-
 
           main_fields_from_resolve_kind
             .map(|field| [field, DEFAULT_MAIN_FIELDS.clone()].concat())

--- a/crates/plugin_resolve/src/resolver.rs
+++ b/crates/plugin_resolve/src/resolver.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::{
   path::{Path, PathBuf},
@@ -16,6 +17,7 @@ use farmfe_core::{
   serde_json::{from_str, Map, Value},
 };
 
+use farmfe_toolkit::lazy_static::lazy_static;
 use farmfe_toolkit::resolve::{follow_symlinks, load_package_json, package_json_loader::Options};
 use farmfe_utils::relative;
 
@@ -40,6 +42,7 @@ pub struct ResolveCacheKey {
   pub base_dir: String,
   pub kind: ResolveKind,
   pub options: ResolveOptions,
+  pub main_fields: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default)]
@@ -56,6 +59,16 @@ pub const NODE_MODULES: &str = "node_modules";
 const BROWSER_SUBPATH_EXTERNAL_ID: &str = "__FARM_BROWSER_SUBPATH_EXTERNAL__";
 const REGEX_PREFIX: &str = "$__farm_regex:";
 const HIGHEST_PRIORITY_FIELD: &str = "exports";
+
+lazy_static! {
+  pub static ref DEFAULT_MAIN_FIELDS: Vec<String> = vec![
+    "browser".to_string(),
+    "module".to_string(),
+    "main".to_string(),
+    "jsnext:main".to_string(),
+    "jsnext".to_string()
+  ];
+}
 
 impl Resolver {
   pub fn new() -> Self {
@@ -84,6 +97,7 @@ impl Resolver {
       base_dir: base_dir.to_string_lossy().to_string(),
       kind: kind.clone(),
       options: options.clone(),
+      main_fields: context.config.resolve.main_fields.clone(),
     };
 
     if let Some(result) = self.resolve_cache.lock().get(&cache_key) {
@@ -483,6 +497,7 @@ impl Resolver {
       base_dir: base_dir.to_string_lossy().to_string(),
       kind: kind.clone(),
       options: options.clone(),
+      main_fields: context.config.resolve.main_fields.clone(),
     }) {
       return result.clone();
     }
@@ -497,6 +512,7 @@ impl Resolver {
         base_dir: tried_path.to_string_lossy().to_string(),
         kind: kind.clone(),
         options: options.clone(),
+        main_fields: context.config.resolve.main_fields.clone(),
       };
 
       if !resolve_node_modules_cache.contains_key(&key) {
@@ -527,6 +543,7 @@ impl Resolver {
         base_dir: current.to_string_lossy().to_string(),
         kind: kind.clone(),
         options: options.clone(),
+        main_fields: context.config.resolve.main_fields.clone(),
       };
 
       if let Some(result) = self.resolve_cache.lock().get(&key) {
@@ -711,39 +728,51 @@ impl Resolver {
         .map(|exports_entries| exports_entries.get(0).unwrap().to_string())
       })
       .or_else(|| {
-        context
-          .config
-          .resolve
-          .main_fields
-          .iter()
-          .find_map(|main_field| {
-            if main_field == "browser" && !context.config.output.target_env.is_browser() {
-              return None;
-            }
-            raw_package_json_info
-              .get(main_field)
-              .and_then(|field_value| match field_value {
-                Value::Object(_) if main_field == "browser" => {
-                  get_field_value_from_package_json_info(&package_json_info, main_field).and_then(
-                    |browser| {
-                      if let Value::Object(browser) = browser {
-                        browser.get(".").and_then(|value| {
-                          if let Value::String(value) = value {
-                            Some(value.to_string())
-                          } else {
-                            None
-                          }
-                        })
-                      } else {
-                        None
-                      }
-                    },
-                  )
-                }
-                Value::String(str) => Some(str.to_string()),
-                _ => None,
-              })
-          })
+        let main_fields = if let Some(ref main_fields) = context.config.resolve.main_fields {
+          Some(Cow::Borrowed(main_fields))
+        } else {
+          let main_fields_from_resolve_kind = match kind {
+            ResolveKind::Require => Some(vec!["main".to_string()]),
+            ResolveKind::Import => Some(vec!["module".to_string()]),
+            _ => None,
+          };
+
+
+          main_fields_from_resolve_kind
+            .map(|field| [field, DEFAULT_MAIN_FIELDS.clone()].concat())
+            .map(Cow::Owned)
+        }
+        .unwrap_or_else(|| Cow::Borrowed(&DEFAULT_MAIN_FIELDS));
+
+        main_fields.iter().find_map(|main_field| {
+          if main_field == "browser" && !context.config.output.target_env.is_browser() {
+            return None;
+          }
+
+          raw_package_json_info
+            .get(main_field)
+            .and_then(|field_value| match field_value {
+              Value::Object(_) if main_field == "browser" => {
+                get_field_value_from_package_json_info(&package_json_info, main_field).and_then(
+                  |browser| {
+                    if let Value::Object(browser) = browser {
+                      browser.get(".").and_then(|value| {
+                        if let Value::String(value) = value {
+                          Some(value.to_string())
+                        } else {
+                          None
+                        }
+                      })
+                    } else {
+                      None
+                    }
+                  },
+                )
+              }
+              Value::String(str) => Some(str.to_string()),
+              _ => None,
+            })
+        })
       });
     if let Some(entry_point) = entry_point {
       let dir = package_json_info.dir();

--- a/crates/plugin_resolve/tests/browser.rs
+++ b/crates/plugin_resolve/tests/browser.rs
@@ -7,6 +7,8 @@ use farmfe_core::{
 };
 use farmfe_plugin_resolve::resolver::{ResolveOptions, Resolver};
 use farmfe_testing_helpers::fixture;
+mod common;
+use common::with_initial_main_fields;
 
 /// See browser field spec (https://github.com/defunctzombie/package-browser-field-spec)
 
@@ -23,8 +25,9 @@ fn resolve_browser_basic() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
+
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
 
@@ -45,7 +48,7 @@ fn resolve_browser_basic() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(
+        &Arc::new(with_initial_main_fields(
           CompilationContext::new(
             Config {
               output: Box::new(OutputConfig {
@@ -57,7 +60,7 @@ fn resolve_browser_basic() {
             vec![],
           )
           .unwrap(),
-        ),
+        )),
       );
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
@@ -264,7 +267,7 @@ fn resolve_browser_entry_replace() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
@@ -284,7 +287,7 @@ fn resolve_browser_entry_replace() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved1.is_some());
       let resolved1 = resolved1.unwrap();

--- a/crates/plugin_resolve/tests/common/mod.rs
+++ b/crates/plugin_resolve/tests/common/mod.rs
@@ -1,0 +1,7 @@
+use farmfe_core::context::CompilationContext;
+use farmfe_plugin_resolve::resolver::DEFAULT_MAIN_FIELDS;
+
+pub fn with_initial_main_fields(mut compilation: CompilationContext) -> CompilationContext {
+  compilation.config.resolve.main_fields = Some(DEFAULT_MAIN_FIELDS.to_vec());
+  compilation
+}

--- a/crates/plugin_resolve/tests/common/mod.rs
+++ b/crates/plugin_resolve/tests/common/mod.rs
@@ -2,6 +2,6 @@ use farmfe_core::context::CompilationContext;
 use farmfe_plugin_resolve::resolver::DEFAULT_MAIN_FIELDS;
 
 pub fn with_initial_main_fields(mut compilation: CompilationContext) -> CompilationContext {
-  compilation.config.resolve.main_fields = Some(DEFAULT_MAIN_FIELDS.to_vec());
+  compilation.config.resolve.main_fields = DEFAULT_MAIN_FIELDS.to_vec();
   compilation
 }

--- a/crates/plugin_resolve/tests/fixtures/resolve-node-modules/resolve-kind/node_modules/pkg-a/cjs.js
+++ b/crates/plugin_resolve/tests/fixtures/resolve-node-modules/resolve-kind/node_modules/pkg-a/cjs.js
@@ -1,0 +1,3 @@
+module.exports = function cjs() {
+  return 'cjs';
+}

--- a/crates/plugin_resolve/tests/fixtures/resolve-node-modules/resolve-kind/node_modules/pkg-a/esm.js
+++ b/crates/plugin_resolve/tests/fixtures/resolve-node-modules/resolve-kind/node_modules/pkg-a/esm.js
@@ -1,0 +1,3 @@
+export default function esm() {
+  return 'esm';
+}

--- a/crates/plugin_resolve/tests/fixtures/resolve-node-modules/resolve-kind/node_modules/pkg-a/package.json
+++ b/crates/plugin_resolve/tests/fixtures/resolve-node-modules/resolve-kind/node_modules/pkg-a/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "pkg-a",
+  "version": "1.0.0",
+  "main": "./cjs.js",
+  "module": "./esm.js"
+}

--- a/crates/plugin_resolve/tests/mod.rs
+++ b/crates/plugin_resolve/tests/mod.rs
@@ -7,6 +7,8 @@ use farmfe_core::{
 };
 use farmfe_plugin_resolve::resolver::{ResolveOptions, Resolver};
 use farmfe_testing_helpers::fixture;
+mod common;
+use common::with_initial_main_fields;
 
 #[test]
 fn resolve_relative_specifier_without_extension() {
@@ -21,7 +23,7 @@ fn resolve_relative_specifier_without_extension() {
         cwd.clone(),
         &ResolveKind::Entry(String::new()),
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
@@ -46,7 +48,7 @@ fn resolve_relative_specifier_with_extension() {
         cwd.clone(),
         &ResolveKind::Entry(String::new()),
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_none());
 
@@ -55,7 +57,7 @@ fn resolve_relative_specifier_with_extension() {
         cwd.clone(),
         &ResolveKind::Entry(String::new()),
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       let resolved = resolved.unwrap();
       assert_eq!(
@@ -79,7 +81,7 @@ fn resolve_node_modules_normal() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
@@ -101,7 +103,7 @@ fn resolve_node_modules_normal() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
@@ -123,7 +125,7 @@ fn resolve_node_modules_normal() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
@@ -146,7 +148,7 @@ fn resolve_node_modules_normal() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
@@ -169,7 +171,7 @@ fn resolve_node_modules_normal() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
@@ -311,7 +313,7 @@ fn resolve_dot() {
       cwd.clone(),
       &ResolveKind::Import,
       &ResolveOptions::default(),
-      &Arc::new(CompilationContext::default()),
+      &Arc::new(with_initial_main_fields(CompilationContext::default())),
     );
     assert!(resolved.is_some());
     let resolved = resolved.unwrap();
@@ -336,7 +338,7 @@ fn resolve_double_dot() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
@@ -367,7 +369,7 @@ fn resolve_absolute_specifier() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
       let resolved = resolved.unwrap();
@@ -379,7 +381,7 @@ fn resolve_absolute_specifier() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
 
       assert!(resolved.is_some());
@@ -410,7 +412,7 @@ fn resolve_package_dir() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
 
@@ -434,7 +436,7 @@ fn resolve_package_end_with_js() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
 
@@ -467,7 +469,7 @@ fn resolve_package_subpath() {
         cwd.clone(),
         &ResolveKind::Import,
         &ResolveOptions::default(),
-        &Arc::new(CompilationContext::default()),
+        &Arc::new(with_initial_main_fields(CompilationContext::default())),
       );
       assert!(resolved.is_some());
 
@@ -483,6 +485,73 @@ fn resolve_package_subpath() {
           .to_string_lossy()
           .to_string()
       );
+    }
+  );
+}
+
+#[test]
+fn resolve_package_resolve_kind() {
+  fixture!(
+    "tests/fixtures/resolve-node-modules/resolve-kind/index.ts",
+    |file, _| {
+      let cwd = file.parent().unwrap().to_path_buf();
+      let resolver = Resolver::new();
+
+      // options
+      for (kind, name) in [
+        (ResolveKind::Import, "esm.js"),
+        (ResolveKind::Require, "cjs.js"),
+      ] {
+        // default mainFields
+
+        let resolved = resolver.resolve(
+          "pkg-a",
+          cwd.clone(),
+          &kind,
+          &ResolveOptions::default(),
+          &Arc::new(CompilationContext::default()),
+        );
+
+        assert!(resolved.is_some());
+
+        let resolved = resolved.unwrap();
+
+        assert_eq!(
+          resolved.resolved_path,
+          cwd
+            .join("node_modules")
+            .join("pkg-a")
+            .join(name)
+            .to_string_lossy()
+            .to_string()
+        );
+
+        let resolved = resolver.resolve(
+          "pkg-a",
+          cwd.clone(),
+          &kind,
+          &ResolveOptions::default(),
+          &Arc::new({
+            let mut context = CompilationContext::default();
+            context.config.resolve.main_fields =
+              Some(vec!["module".to_string(), "main".to_string()]);
+            context
+          }),
+        );
+
+        assert!(resolved.is_some());
+
+        let resolved = resolved.unwrap();
+        assert_eq!(
+          resolved.resolved_path,
+          cwd
+            .join("node_modules")
+            .join("pkg-a")
+            .join("esm.js")
+            .to_string_lossy()
+            .to_string()
+        );
+      }
     }
   );
 }

--- a/crates/plugin_resolve/tests/mod.rs
+++ b/crates/plugin_resolve/tests/mod.rs
@@ -533,8 +533,7 @@ fn resolve_package_resolve_kind() {
           &ResolveOptions::default(),
           &Arc::new({
             let mut context = CompilationContext::default();
-            context.config.resolve.main_fields =
-              Some(vec!["module".to_string(), "main".to_string()]);
+            context.config.resolve.main_fields = vec!["module".to_string(), "main".to_string()];
             context
           }),
         );


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced package resolution: The system now supports flexible configuration of module resolution settings, enabling optional customization of primary resolution fields. When no explicit configuration is provided, a robust default is applied to streamline module resolution across various setups.
  - Introduction of a new test for resolving package kinds using different configurations of main fields.

- **Bug Fixes**
  - Improved handling of the `CompilationContext` in tests for better accuracy in resolution logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->