### PR TITLE
fix: resolve the relative path of projects

### DIFF
--- a/js-plugins/sass/src/index.ts
+++ b/js-plugins/sass/src/index.ts
@@ -195,6 +195,12 @@ async function resolveDependency(
     if (existsSync(relPath) && statSync(relPath).isFile()) {
       return relPath;
     }
+
+    const cwd = process.cwd();
+    const projectPath = path.resolve(cwd, url);
+    if (existsSync(relPath) && statSync(relPath).isFile()) {
+      return projectPath;
+    }
   }
 
   const try_prefix_list = ['_'];


### PR DESCRIPTION
If it is not an absolute path and is not a relative path to the file currently being parsed, should determine if it is a relative path to the current project path, such as starts with src.

For example: "src/xxx/xxx"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of non-absolute URLs in dependency resolution to ensure correct file path resolution in more scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->