### PR TITLE
fix: resolve the relative path of projects

### DIFF
--- a/.changeset/js-plugin-sass.md
+++ b/.changeset/js-plugin-sass.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/js-plugin-sass": patch
+---
+
+fix: resolve the relative path of projects

--- a/js-plugins/sass/src/index.ts
+++ b/js-plugins/sass/src/index.ts
@@ -195,6 +195,12 @@ async function resolveDependency(
     if (existsSync(relPath) && statSync(relPath).isFile()) {
       return relPath;
     }
+
+    const cwd = process.cwd();
+    const projectPath = path.resolve(cwd, url);
+    if (existsSync(projectPath) && statSync(projectPath).isFile()) {
+      return projectPath;
+    }
   }
 
   const try_prefix_list = ['_'];


### PR DESCRIPTION
If it is not an absolute path and is not a relative path to the file currently being parsed, should determine if it is a relative path to the current project path, such as starts with src.

For example: "src/xxx/xxx"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resolution of relative paths within projects, ensuring better handling of non-absolute URLs in SASS files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->