### PR TITLE
fix: tree shake issue when handling cross module top level variables …

### DIFF
--- a/.changeset/smart-crabs-rest.md
+++ b/.changeset/smart-crabs-rest.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+Fix tree shake issue when writing variables defined in external package

--- a/crates/compiler/tests/fixtures/tree_shake/export_ns_all/all.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/export_ns_all/all.ts
@@ -1,0 +1,5 @@
+export default 'default';
+// TODO following exports can be removed, we may optimize it in the future
+export const a = 'a';
+export const b = 'b';
+export const c = 'c';

--- a/crates/compiler/tests/fixtures/tree_shake/export_ns_all/index.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/export_ns_all/index.ts
@@ -1,0 +1,3 @@
+import { ns } from './ns';
+
+console.log(ns.default);

--- a/crates/compiler/tests/fixtures/tree_shake/export_ns_all/ns.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/export_ns_all/ns.ts
@@ -1,0 +1,1 @@
+export * as ns from './all';

--- a/crates/compiler/tests/fixtures/tree_shake/export_ns_all/output.js
+++ b/crates/compiler/tests/fixtures/tree_shake/export_ns_all/output.js
@@ -65,26 +65,34 @@
     window['__farm_default_namespace__'].__farm_module_system__.setPlugins([]);
 });
 index_js_cjs();
-})());(function(_){var filename = ((function(){var _documentCurrentScript = typeof document !== "undefined" ? document.currentScript : null;return typeof document === "undefined" ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && _documentCurrentScript.src || new URL("index_7104.js", document.baseURI).href})());for(var r in _){_[r].__farm_resource_pot__=filename;window['__farm_default_namespace__'].__farm_module_system__.register(r,_[r])}})({"b5d64806":function  (module, exports, farmRequire, farmDynamicRequire) {
+})());(function(_){var filename = ((function(){var _documentCurrentScript = typeof document !== "undefined" ? document.currentScript : null;return typeof document === "undefined" ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && _documentCurrentScript.src || new URL("index_8208.js", document.baseURI).href})());for(var r in _){_[r].__farm_resource_pot__=filename;window['__farm_default_namespace__'].__farm_module_system__.register(r,_[r])}})({"8ed0341c":function  (module, exports, farmRequire, farmDynamicRequire) {
     module._m(exports);
-    var _f_b = module.w(farmRequire("f380ea31"));
-    var A = _f_b;
-    console.log(A.A);
-    const B = A['B'];
-    console.log(B);
-    console.log(A.default);
+    module.o(exports, "ns", function() {
+        return ns;
+    });
+    var ns = module.w(farmRequire("c8a5517e"));
 }
 ,
-"f380ea31":function  (module, exports, farmRequire, farmDynamicRequire) {
+"b5d64806":function  (module, exports, farmRequire, farmDynamicRequire) {
     module._m(exports);
-    module.o(exports, "A", function() {
-        return A;
+    var _f_ns = farmRequire("8ed0341c");
+    console.log(_f_ns.ns.default);
+}
+,
+"c8a5517e":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    module.o(exports, "a", function() {
+        return a;
     });
-    module.o(exports, "B", function() {
-        return B;
+    module.o(exports, "b", function() {
+        return b;
     });
-    var A = 10;
-    var B = 20;
-    exports.default = 'hello';
+    module.o(exports, "c", function() {
+        return c;
+    });
+    exports.default = 'default';
+    var a = 'a';
+    var b = 'b';
+    var c = 'c';
 }
 ,});window['__farm_default_namespace__'].__farm_module_system__.setInitialLoadedResources([]);window['__farm_default_namespace__'].__farm_module_system__.setDynamicModuleResourcesMap([],{  });var farmModuleSystem = window['__farm_default_namespace__'].__farm_module_system__;farmModuleSystem.bootstrap();var entry = farmModuleSystem.require("b5d64806");

--- a/crates/compiler/tests/fixtures/tree_shake/import_namespace/partial/b.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/import_namespace/partial/b.ts
@@ -3,3 +3,5 @@ export const A = 10;
 export const B = 20;
 
 export const C = 30;
+
+export default 'hello';

--- a/crates/compiler/tests/fixtures/tree_shake/import_namespace/partial/index.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/import_namespace/partial/index.ts
@@ -5,3 +5,5 @@ console.log(A.A);
 const B = A['B'];
 
 console.log(B);
+
+console.log(A.default);

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/dep.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/dep.ts
@@ -1,0 +1,14 @@
+import { nativeWindow, emptyWindow } from "./dep3"; // should be preserved
+
+export const a: any = {
+  field: '1',
+  Camera: undefined,
+}; // should be preserved
+
+const nativeLocation = nativeWindow.location; // should be preserved
+
+export const b: any = nativeLocation; // should be preserved cause it may contain side effects
+
+export const c: any = {}; // should be removed as it is not used
+
+export const d = emptyWindow; // should be removed as it is not used and does not contain side effects

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/dep2.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/dep2.ts
@@ -1,0 +1,11 @@
+export const a = {
+  field: '1',
+};
+
+export const b = window; // should be preserved
+
+const Ani = window.Animation; // should be preserved
+export const Animation = Ani; // should be preserved
+Animation.prototype.run = function () {
+  console.log('run');
+}; // should be preserved

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/dep3.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/dep3.ts
@@ -1,0 +1,2 @@
+export const nativeWindow = document.defaultView || window || self;
+export const emptyWindow: any = {};

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/index.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/index.ts
@@ -1,0 +1,24 @@
+import { runtime, Camera } from '@antv/g';
+import { a } from './dep';
+import * as ns from './dep';
+import * as ns_copy from './dep';
+import * as ns2 from './dep2';
+
+var AdvancedCamera = /*#__PURE__*/function(_Camera) {
+  return _Camera;
+}(Camera);
+
+// this has side effects for ident a, so we should preserve the import statement
+ns.a.Camera = AdvancedCamera;
+const ns_a = ns_copy.a;
+ns_a.field = 'ns_a'; // should be preserved
+ns.b.field = 'b'; // should be preserved as it contains side effects
+
+ns.c.field = 'c'; // should be removed as it is not used
+ns.d.field = 'd'; // should be removed as it is not used and does not contain side effects
+
+// we don't know the field is a or b, so we should preserve the all export of dep2
+// cause if we remove the export, a runtime error will be thrown when the field cannot be found
+ns2[window.document.DOCUMENT_FRAGMENT_NODE].field = '2';
+
+console.log(runtime.AnimationTimeline, a);

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g-lite/index.js
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g-lite/index.js
@@ -1,0 +1,4 @@
+export const runtime = {};
+export const runtime_should_be_removed = {};
+export const runtime_should_be_preserved = window;
+export function Camera() {};

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g-lite/package.json
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g-lite/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@antv/g-lite",
+  "main": "index.js"
+}

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g-web-animations-api/index.js
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g-web-animations-api/index.js
@@ -1,0 +1,11 @@
+import { runtime as importedRuntime, runtime_should_be_removed, runtime_should_be_preserved } from '@antv/g-lite';
+
+class AnimationTimeline {}
+
+const runtime = importedRuntime;
+
+runtime.AnimationTimeline = AnimationTimeline;
+runtime_should_be_removed.AnimationTimeline = AnimationTimeline;
+runtime_should_be_preserved.AnimationTimeline = AnimationTimeline;
+
+export { AnimationTimeline };

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g-web-animations-api/package.json
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g-web-animations-api/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@antv/g-web-animations-api",
+  "main": "index.js"
+}

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g/index.js
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g/index.js
@@ -1,0 +1,2 @@
+export * from '@antv/g-lite';
+export * from '@antv/g-web-animations-api';

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g/package.json
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/node_modules/@antv/g/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@antv/g",
+  "main": "index.js"
+}

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/output.js
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_imported_idents/output.js
@@ -1,0 +1,174 @@
+//__farm_runtime.js:
+ window['__farm_default_namespace__'] = {__FARM_TARGET_ENV__: 'browser'};function _interop_require_default(obj) {
+    return obj && obj.__esModule ? obj : {
+        default: obj
+    };
+}function _export_star(from, to) {
+    Object.keys(from).forEach(function(k) {
+        if (k !== "default" && !Object.prototype.hasOwnProperty.call(to, k)) {
+            Object.defineProperty(to, k, {
+                enumerable: true,
+                get: function() {
+                    return from[k];
+                }
+            });
+        }
+    });
+    return from;
+}function _interop_require_wildcard(obj, nodeInterop) {
+    if (!nodeInterop && obj && obj.__esModule) return obj;
+    if (obj === null || typeof obj !== "object" && typeof obj !== "function") return {
+        default: obj
+    };
+    var cache = _getRequireWildcardCache(nodeInterop);
+    if (cache && cache.has(obj)) return cache.get(obj);
+    var newObj = {
+        __proto__: null
+    };
+    var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor;
+    for(var key in obj){
+        if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) {
+            var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null;
+            if (desc && (desc.get || desc.set)) Object.defineProperty(newObj, key, desc);
+            else newObj[key] = obj[key];
+        }
+    }
+    newObj.default = obj;
+    if (cache) cache.set(obj, newObj);
+    return newObj;
+}function _getRequireWildcardCache(nodeInterop) {
+    if (typeof WeakMap !== "function") return null;
+    var cacheBabelInterop = new WeakMap();
+    var cacheNodeInterop = new WeakMap();
+    return (_getRequireWildcardCache = function(nodeInterop) {
+        return nodeInterop ? cacheNodeInterop : cacheBabelInterop;
+    })(nodeInterop);
+}function __commonJs(mod) {
+  var module;
+  return () => {
+    if (module) {
+      return module.exports;
+    }
+    module = {
+      exports: {},
+    };
+    if(typeof mod === "function") {
+      mod(module, module.exports);
+    }else {
+      mod[Object.keys(mod)[0]](module, module.exports);
+    }
+    return module.exports;
+  };
+}((function(){var index_js_cjs = __commonJs((module, exports)=>{
+    "use strict";
+    console.log('runtime/index.js');
+    window['__farm_default_namespace__'].__farm_module_system__.setPlugins([]);
+});
+index_js_cjs();
+})());
+
+//index.js:
+ import "./__farm_runtime.js";import "./index_f595.js";(function(_){var filename = ((function(){var _documentCurrentScript = typeof document !== "undefined" ? document.currentScript : null;return typeof document === "undefined" ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && _documentCurrentScript.src || new URL("index_f385.js", document.baseURI).href})());for(var r in _){_[r].__farm_resource_pot__=filename;window['__farm_default_namespace__'].__farm_module_system__.register(r,_[r])}})({"05ee5ec7":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    module.o(exports, "a", function() {
+        return a;
+    });
+    module.o(exports, "b", function() {
+        return b;
+    });
+    var _f_dep3 = farmRequire("1111770e");
+    var a = {
+        field: '1',
+        Camera: undefined
+    };
+    const nativeLocation = _f_dep3.nativeWindow.location;
+    var b = nativeLocation;
+}
+,
+"1111770e":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    module.o(exports, "nativeWindow", function() {
+        return nativeWindow;
+    });
+    var nativeWindow = document.defaultView || window || self;
+}
+,
+"b5d64806":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    var _f_g = farmRequire("7700579b");
+    var _f_dep = farmRequire("05ee5ec7");
+    var _f_dep1 = module.w(farmRequire("05ee5ec7"));
+    var ns = _f_dep1;
+    var _f_dep2 = module.w(farmRequire("05ee5ec7"));
+    var ns_copy = _f_dep2;
+    var _f_dep21 = module.w(farmRequire("cf66b21c"));
+    var ns2 = _f_dep21;
+    var AdvancedCamera = function(_Camera) {
+        return _Camera;
+    }(_f_g.Camera);
+    ns.a.Camera = AdvancedCamera;
+    const ns_a = ns_copy.a;
+    ns_a.field = 'ns_a';
+    ns.b.field = 'b';
+    ns2[window.document.DOCUMENT_FRAGMENT_NODE].field = '2';
+    console.log(_f_g.runtime.AnimationTimeline, _f_dep.a);
+}
+,
+"cf66b21c":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    module.o(exports, "a", function() {
+        return a;
+    });
+    module.o(exports, "b", function() {
+        return b;
+    });
+    module.o(exports, "Animation", function() {
+        return Animation;
+    });
+    var a = {
+        field: '1'
+    };
+    var b = window;
+    const Ani = window.Animation;
+    var Animation = Ani;
+    Animation.prototype.run = function() {
+        console.log('run');
+    };
+}
+,});window['__farm_default_namespace__'].__farm_module_system__.setInitialLoadedResources(['index_f595.js']);window['__farm_default_namespace__'].__farm_module_system__.setDynamicModuleResourcesMap([],{  });var farmModuleSystem = window['__farm_default_namespace__'].__farm_module_system__;farmModuleSystem.bootstrap();var entry = farmModuleSystem.require("b5d64806");
+
+//index_f595.js:
+ (function(_){var filename = ((function(){var _documentCurrentScript = typeof document !== "undefined" ? document.currentScript : null;return typeof document === "undefined" ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && _documentCurrentScript.src || new URL("index_f595.js", document.baseURI).href})());for(var r in _){_[r].__farm_resource_pot__=filename;window['__farm_default_namespace__'].__farm_module_system__.register(r,_[r])}})({"5650438d":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    var _f_g_lite = farmRequire("7927f9cf");
+    class AnimationTimeline {
+    }
+    const runtime = _f_g_lite.runtime;
+    runtime.AnimationTimeline = AnimationTimeline;
+    _f_g_lite.runtime_should_be_preserved.AnimationTimeline = AnimationTimeline;
+}
+,
+"7700579b":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    var _f_g_lite = farmRequire("7927f9cf");
+    module._e(exports, _f_g_lite);
+    var _f_g_web_animations_api = farmRequire("5650438d");
+    module._e(exports, _f_g_web_animations_api);
+}
+,
+"7927f9cf":function  (module, exports, farmRequire, farmDynamicRequire) {
+    module._m(exports);
+    module.o(exports, "runtime", function() {
+        return runtime;
+    });
+    module.o(exports, "runtime_should_be_preserved", function() {
+        return runtime_should_be_preserved;
+    });
+    module.o(exports, "Camera", function() {
+        return Camera;
+    });
+    var runtime = {};
+    var runtime_should_be_preserved = window;
+    function Camera() {}
+}
+,});

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_read_top_level_var/dep.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_read_top_level_var/dep.ts
@@ -1,0 +1,17 @@
+function foo() {
+  console.log("foo");
+}
+
+function bar() {
+  console.log("bar");
+}
+
+foo.prototype.runFoo = function () {
+  console.log("runFoo");
+};
+
+const tempBar = bar;
+
+tempBar.prototype.runFoo = foo.prototype.runFoo;
+
+export { bar };

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_read_top_level_var/index.ts
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_read_top_level_var/index.ts
@@ -1,0 +1,3 @@
+import { bar } from "./dep";
+
+new bar().runFoo();

--- a/crates/compiler/tests/fixtures/tree_shake/self-executed/write_read_top_level_var/output.js
+++ b/crates/compiler/tests/fixtures/tree_shake/self-executed/write_read_top_level_var/output.js
@@ -65,26 +65,27 @@
     window['__farm_default_namespace__'].__farm_module_system__.setPlugins([]);
 });
 index_js_cjs();
-})());(function(_){var filename = ((function(){var _documentCurrentScript = typeof document !== "undefined" ? document.currentScript : null;return typeof document === "undefined" ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && _documentCurrentScript.src || new URL("index_7104.js", document.baseURI).href})());for(var r in _){_[r].__farm_resource_pot__=filename;window['__farm_default_namespace__'].__farm_module_system__.register(r,_[r])}})({"b5d64806":function  (module, exports, farmRequire, farmDynamicRequire) {
+})());(function(_){var filename = ((function(){var _documentCurrentScript = typeof document !== "undefined" ? document.currentScript : null;return typeof document === "undefined" ? require("url").pathToFileURL(__filename).href : _documentCurrentScript && _documentCurrentScript.src || new URL("index_ddf1.js", document.baseURI).href})());for(var r in _){_[r].__farm_resource_pot__=filename;window['__farm_default_namespace__'].__farm_module_system__.register(r,_[r])}})({"05ee5ec7":function  (module, exports, farmRequire, farmDynamicRequire) {
     module._m(exports);
-    var _f_b = module.w(farmRequire("f380ea31"));
-    var A = _f_b;
-    console.log(A.A);
-    const B = A['B'];
-    console.log(B);
-    console.log(A.default);
+    module.o(exports, "bar", function() {
+        return bar;
+    });
+    function foo() {
+        console.log("foo");
+    }
+    function bar() {
+        console.log("bar");
+    }
+    foo.prototype.runFoo = function() {
+        console.log("runFoo");
+    };
+    const tempBar = bar;
+    tempBar.prototype.runFoo = foo.prototype.runFoo;
 }
 ,
-"f380ea31":function  (module, exports, farmRequire, farmDynamicRequire) {
+"b5d64806":function  (module, exports, farmRequire, farmDynamicRequire) {
     module._m(exports);
-    module.o(exports, "A", function() {
-        return A;
-    });
-    module.o(exports, "B", function() {
-        return B;
-    });
-    var A = 10;
-    var B = 20;
-    exports.default = 'hello';
+    var _f_dep = farmRequire("05ee5ec7");
+    new _f_dep.bar().runFoo();
 }
 ,});window['__farm_default_namespace__'].__farm_module_system__.setInitialLoadedResources([]);window['__farm_default_namespace__'].__farm_module_system__.setDynamicModuleResourcesMap([],{  });var farmModuleSystem = window['__farm_default_namespace__'].__farm_module_system__;farmModuleSystem.bootstrap();var entry = farmModuleSystem.require("b5d64806");

--- a/crates/compiler/tests/tree_shake.rs
+++ b/crates/compiler/tests/tree_shake.rs
@@ -27,6 +27,9 @@ mod common;
 fn tree_shake_test() {
   fixture!(
     "tests/fixtures/tree_shake/**/index.ts",
+    // "tests/fixtures/tree_shake/self-executed/write_imported_idents/**/index.ts",
+    // "tests/fixtures/tree_shake/self-executed/write_read_top_level_var/**/index.ts",
+    // "tests/fixtures/tree_shake/import_namespace/partial/**/index.ts",
     |file, crate_path| {
       let cwd = file.parent().unwrap();
       println!("testing tree shake: {cwd:?}");

--- a/crates/plugin_tree_shake/src/statement_graph/analyze_statement_side_effects/test.rs
+++ b/crates/plugin_tree_shake/src/statement_graph/analyze_statement_side_effects/test.rs
@@ -103,7 +103,7 @@ fn write_top_level_var() {
       super::StatementSideEffects::WriteTopLevelVar(var_name) => {
         let mut idents = var_name
           .into_iter()
-          .map(|i| format!("{}{:?}", i.0, i.1))
+          .map(|i| format!("{}{:?}", i.ident.0, i.ident.1))
           .collect::<Vec<_>>();
         idents.sort();
         idents
@@ -127,7 +127,7 @@ fn write_top_level_var() {
       super::StatementSideEffects::WriteTopLevelVar(var_name) => {
         let mut idents = var_name
           .into_iter()
-          .map(|i| format!("{}{:?}", i.0, i.1))
+          .map(|i| format!("{}{:?}", i.ident.0, i.ident.1))
           .collect::<Vec<_>>();
         idents.sort();
         idents

--- a/crates/plugin_tree_shake/src/statement_graph/analyze_written_imported_idents.rs
+++ b/crates/plugin_tree_shake/src/statement_graph/analyze_written_imported_idents.rs
@@ -1,0 +1,85 @@
+use std::collections::{HashMap, HashSet};
+
+use farmfe_core::swc_ecma_ast::Id;
+
+use super::{
+  analyze_used_import_all_fields::UsedImportAllFields, StatementGraph, StatementSideEffects,
+  WriteTopLevelVar,
+};
+
+pub fn analyze_written_imported_idents(graph: &StatementGraph) -> HashSet<WriteTopLevelVar> {
+  let mut written_imported_idents = HashSet::default();
+
+  for stmt in graph.stmts() {
+    if let StatementSideEffects::WriteTopLevelVar(write_top_level_vars) = &stmt.side_effects {
+      let idents = write_top_level_vars
+        .iter()
+        .map(|v| v.ident.clone())
+        .collect::<HashSet<_>>();
+
+      let used_import_all_field = write_top_level_vars
+        .iter()
+        .map(|v| {
+          (
+            v.ident.clone(),
+            v.fields
+              .as_ref()
+              .map(|f| f.iter().map(|f| f.clone()).collect())
+              .unwrap_or_default(),
+          )
+        })
+        .collect::<HashMap<_, _>>();
+
+      written_imported_idents.extend(find_written_imported_idents_dfs(
+        &idents,
+        &used_import_all_field,
+        graph,
+        &mut HashSet::default(),
+      ))
+    }
+  }
+
+  written_imported_idents
+}
+
+fn find_written_imported_idents_dfs(
+  idents: &HashSet<Id>,
+  used_import_all_fields: &HashMap<Id, HashSet<UsedImportAllFields>>,
+  graph: &StatementGraph,
+  visited: &mut HashSet<Id>,
+) -> HashSet<WriteTopLevelVar> {
+  let mut written_imported_idents = HashSet::default();
+
+  for ident in idents {
+    if visited.contains(ident) {
+      continue;
+    }
+
+    visited.insert(ident.clone());
+
+    if let Some(stmt_id) = graph.reverse_defined_idents_map.get(ident) {
+      let dep_stmt = graph.stmt(stmt_id);
+
+      if dep_stmt.import_info.is_some() {
+        let fields = used_import_all_fields.get(ident).cloned();
+        written_imported_idents.insert(WriteTopLevelVar {
+          ident: ident.clone(),
+          fields: fields.map(|f| f.into_iter().collect()),
+        });
+      } else {
+        for (_, edge) in graph.dependencies(stmt_id) {
+          if let Some(dep_idents) = edge.used_idents_map.get(ident) {
+            written_imported_idents.extend(find_written_imported_idents_dfs(
+              dep_idents,
+              &edge.used_import_all_fields,
+              graph,
+              visited,
+            ));
+          }
+        }
+      }
+    }
+  }
+
+  written_imported_idents
+}

--- a/crates/plugin_tree_shake/src/statement_graph/traced_used_import.rs
+++ b/crates/plugin_tree_shake/src/statement_graph/traced_used_import.rs
@@ -85,11 +85,13 @@ impl TracedUsedImportStatement {
                 for used_import_all_field in used_import_all_fields {
                   match used_import_all_field {
                     UsedImportAllFields::All => unreachable!(),
-                    UsedImportAllFields::Ident(field) => {
-                      used_stmt_idents.insert(UsedExportsIdent::SwcIdent(field));
-                    }
-                    UsedImportAllFields::LiteralComputed(field) => {
-                      used_stmt_idents.insert(UsedExportsIdent::SwcIdent(field));
+                    UsedImportAllFields::Ident(field)
+                    | UsedImportAllFields::LiteralComputed(field) => {
+                      if &field == "default" {
+                        used_stmt_idents.insert(UsedExportsIdent::Default);
+                      } else {
+                        used_stmt_idents.insert(UsedExportsIdent::SwcIdent(field));
+                      }
                     }
                   }
                 }
@@ -143,7 +145,7 @@ impl TracedUsedImportStatement {
         match specifier {
           ExportSpecifierInfo::Namespace(i) => {
             if used_defined_idents.contains(&UsedStatementIdent::SwcIdent(i.clone())) {
-              used_stmt_idents.insert(UsedExportsIdent::ExportAll);
+              used_stmt_idents.insert(UsedExportsIdent::ImportAll);
             }
           }
           ExportSpecifierInfo::Named { local, .. } => {

--- a/crates/plugin_tree_shake/src/tree_shake_modules.rs
+++ b/crates/plugin_tree_shake/src/tree_shake_modules.rs
@@ -1,13 +1,18 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use farmfe_core::{
-  module::{module_graph::ModuleGraph, ModuleId},
+  module::{module_graph::ModuleGraph, ModuleId, ModuleSystem},
   plugin::ResolveKind,
+  swc_ecma_ast::Id,
 };
 
 use crate::{
-  module::{TreeShakeModule, UsedExports},
-  statement_graph::traced_used_import::TracedUsedImportStatement,
+  module::{TreeShakeModule, UsedExports, UsedExportsIdent},
+  statement_graph::{
+    analyze_used_import_all_fields::UsedImportAllFields,
+    traced_used_import::TracedUsedImportStatement, StatementId, StatementSideEffects,
+    UsedStatementIdent,
+  },
 };
 
 pub mod remove_useless_stmts;
@@ -17,8 +22,50 @@ pub fn tree_shake_modules(
   module_graph: &mut ModuleGraph,
   tree_shake_modules_map: &mut HashMap<ModuleId, TreeShakeModule>,
 ) -> Vec<ModuleId> {
-  let mut tree_shake_module_ids_queue = VecDeque::from(entry_module_ids);
   let mut visited_modules: HashSet<ModuleId> = HashSet::new();
+
+  // 1. traverse the tree_shake_modules in order, and trace the used import/used and mark all statement that should be preserved
+  traverse_tree_shake_modules(
+    entry_module_ids,
+    module_graph,
+    tree_shake_modules_map,
+    &mut visited_modules,
+  );
+
+  // 2. traverse the tree_shake_modules in order, handle SideEffects::WriteTopLevelVar that writes imported ident,
+  //  2.1 if the the imported idents are used, we should preserve it
+  //  2.2 if the imported idents are read global variables, we should preserve it
+  let extra_visited_modules =
+    trace_and_mark_write_imported_idents_statements(tree_shake_modules_map, module_graph);
+
+  visited_modules.extend(extra_visited_modules);
+
+  // 3. remove statements that should is not used
+  for tree_shake_module_id in &visited_modules {
+    if tree_shake_modules_map.contains_key(tree_shake_module_id) {
+      remove_useless_stmts::remove_useless_stmts(
+        tree_shake_module_id,
+        module_graph,
+        tree_shake_modules_map,
+      );
+    }
+  }
+
+  module_graph
+    .modules()
+    .into_iter()
+    .map(|m| m.id.clone())
+    .filter(|m_id| !visited_modules.contains(m_id))
+    .collect()
+}
+
+fn traverse_tree_shake_modules(
+  entry_module_ids: Vec<ModuleId>,
+  module_graph: &mut ModuleGraph,
+  tree_shake_modules_map: &mut HashMap<ModuleId, TreeShakeModule>,
+  visited_modules: &mut HashSet<ModuleId>,
+) {
+  let mut tree_shake_module_ids_queue = VecDeque::from(entry_module_ids);
 
   let set_dep_used_export_all =
     |dep_id: &ModuleId, tree_shake_modules_map: &mut HashMap<ModuleId, TreeShakeModule>| {
@@ -29,7 +76,6 @@ pub fn tree_shake_modules(
       }
     };
 
-  // 1. traverse the tree_shake_modules in order, and mark all statement that should be preserved
   while let Some(tree_shake_module_id) = tree_shake_module_ids_queue.pop_front() {
     // handle non tree shakeable modules like css
     if !tree_shake_modules_map.contains_key(&tree_shake_module_id) {
@@ -81,64 +127,68 @@ pub fn tree_shake_modules(
       let traced_import_stmts =
         trace_and_mark_used_statements(&tree_shake_module_id, module_graph, tree_shake_modules_map);
       // set dependencies' pending_used_exports
-      for import_stmt in traced_import_stmts {
-        let TracedUsedImportStatement {
-          source,
-          used_stmt_idents,
-          kind,
-          ..
-        } = import_stmt;
+      let module_ids = set_pending_used_exports(
+        &tree_shake_module_id,
+        module_graph,
+        tree_shake_modules_map,
+        traced_import_stmts,
+      );
 
-        let dep_id = module_graph.get_dep_by_source(&tree_shake_module_id, &source, Some(kind));
-
-        if let Some(dep_tree_shake_module) = tree_shake_modules_map.get_mut(&dep_id) {
-          match used_stmt_idents {
-            UsedExports::All => {
-              dep_tree_shake_module.pending_used_exports.set_export_all();
-            }
-            UsedExports::Partial(used_stmt_idents) => {
-              // add all unhandled used stmt idents to pending_used_exports
-              for used_stmt_ident in used_stmt_idents {
-                if !dep_tree_shake_module
-                  .handled_used_exports
-                  .contains(&used_stmt_ident)
-                {
-                  dep_tree_shake_module
-                    .pending_used_exports
-                    .add_used_export(used_stmt_ident);
-                }
-              }
-            }
-          }
-        }
-
-        tree_shake_module_ids_queue.push_back(dep_id);
+      for module_id in module_ids {
+        tree_shake_module_ids_queue.push_back(module_id);
       }
     }
   }
+}
 
-  // 2. remove statements that should is not used
-  for tree_shake_module_id in &visited_modules {
-    if tree_shake_modules_map.contains_key(tree_shake_module_id) {
-      remove_useless_stmts::remove_useless_stmts(
-        tree_shake_module_id,
-        module_graph,
-        tree_shake_modules_map,
-      );
+fn set_pending_used_exports(
+  tree_shake_module_id: &ModuleId,
+  module_graph: &ModuleGraph,
+  tree_shake_modules_map: &mut HashMap<ModuleId, TreeShakeModule>,
+  traced_import_stmts: Vec<TracedUsedImportStatement>,
+) -> Vec<ModuleId> {
+  let mut module_ids = vec![];
+
+  for import_stmt in traced_import_stmts {
+    let TracedUsedImportStatement {
+      source,
+      used_stmt_idents,
+      kind,
+      ..
+    } = import_stmt;
+
+    let dep_id = module_graph.get_dep_by_source(&tree_shake_module_id, &source, Some(kind));
+
+    if let Some(dep_tree_shake_module) = tree_shake_modules_map.get_mut(&dep_id) {
+      match used_stmt_idents {
+        UsedExports::All => {
+          dep_tree_shake_module.pending_used_exports.set_export_all();
+        }
+        UsedExports::Partial(used_stmt_idents) => {
+          // add all unhandled used stmt idents to pending_used_exports
+          for used_stmt_ident in used_stmt_idents {
+            if !dep_tree_shake_module
+              .handled_used_exports
+              .contains(&used_stmt_ident)
+            {
+              dep_tree_shake_module
+                .pending_used_exports
+                .add_used_export(used_stmt_ident);
+            }
+          }
+        }
+      }
     }
+
+    module_ids.push(dep_id);
   }
 
-  module_graph
-    .modules()
-    .into_iter()
-    .map(|m| m.id.clone())
-    .filter(|m_id| !visited_modules.contains(m_id))
-    .collect()
+  module_ids
 }
 
 fn trace_and_mark_used_statements(
   tree_shake_module_id: &ModuleId,
-  module_graph: &mut ModuleGraph,
+  module_graph: &ModuleGraph,
   tree_shake_modules_map: &mut HashMap<ModuleId, TreeShakeModule>,
 ) -> Vec<TracedUsedImportStatement> {
   let tree_shake_module = tree_shake_modules_map
@@ -231,4 +281,414 @@ fn trace_and_mark_used_statements(
   }
 
   traced_import_stmts
+}
+
+/// For case like:
+/// import { a } from './src/foo';
+/// a.field = 1;
+/// export { a };
+///
+/// a is not used in the module, but it is used in the module's dependency, this has side effects for ident a, so we should preserve the import statement
+fn trace_and_mark_write_imported_idents_statements(
+  tree_shake_modules_map: &mut HashMap<ModuleId, TreeShakeModule>,
+  module_graph: &mut ModuleGraph,
+) -> HashSet<ModuleId> {
+  let mut tree_shake_modules_to_trace = vec![];
+  let mut write_side_effects_to_trace = vec![];
+
+  for tree_shake_module in tree_shake_modules_map.values() {
+    if !tree_shake_module
+      .stmt_graph
+      .written_imported_idents
+      .is_empty()
+    {
+      let mut used_stmt_exports = HashMap::default();
+      let mut used_import_all_fields = HashMap::default();
+
+      for written_imported_ident in &tree_shake_module.stmt_graph.written_imported_idents {
+        if let Some(stmt_id) = tree_shake_module
+          .stmt_graph
+          .reverse_defined_idents_map
+          .get(&written_imported_ident.ident)
+        {
+          // if the imported ident is marked as used in the dep module, we should preserve the import statement
+          let stmt = tree_shake_module.stmt_graph.stmt(stmt_id);
+          let import_info = stmt.import_info.as_ref().unwrap();
+          let source = import_info.source.as_str();
+          let dep_module_id = module_graph.get_dep_by_source(
+            &tree_shake_module.module_id,
+            source,
+            Some(ResolveKind::Import),
+          );
+
+          if let Some(dep_tree_shake_module) = tree_shake_modules_map.get(&dep_module_id) {
+            // if the dep module is not esm, we should always preserve the import statement
+            if !matches!(dep_tree_shake_module.module_system, ModuleSystem::EsModule) {
+              used_stmt_exports
+                .entry(*stmt_id)
+                .or_insert_with(HashSet::new)
+                .insert(UsedStatementIdent::SwcIdent(
+                  written_imported_ident.ident.clone(),
+                ));
+              continue;
+            }
+
+            for specifier in &import_info.specifiers {
+              match specifier {
+                crate::statement_graph::ImportSpecifierInfo::Namespace(ns) => {
+                  if ns == &written_imported_ident.ident {
+                    if let Some(fields) = &written_imported_ident.fields {
+                      let used_fields = used_import_all_fields
+                        .entry(written_imported_ident.ident.clone())
+                        .or_insert_with(HashSet::new);
+
+                      for field in fields {
+                        match field {
+                          UsedImportAllFields::All => {
+                            // This case is handled in previous round of tree shaking, all exports are preserved in this case
+                          }
+                          UsedImportAllFields::Ident(field_str)
+                          | UsedImportAllFields::LiteralComputed(field_str) => {
+                            // 1. whether the export is being used in the dep module
+                            if dep_tree_shake_module
+                              .handled_used_exports
+                              .contains(&UsedExportsIdent::SwcIdent(field_str.to_string()))
+                            {
+                              used_stmt_exports
+                                .entry(*stmt_id)
+                                .or_insert_with(HashSet::new)
+                                .insert(UsedStatementIdent::SwcIdent(
+                                  written_imported_ident.ident.clone(),
+                                ));
+
+                              used_fields.insert(field.clone());
+                            } else {
+                              // 2. if the export is not being used in the dep module, we should trace the dep module to find if the export idents use global variables
+                              write_side_effects_to_trace.push(
+                                TraceDepModuleWriteSideEffectsItem {
+                                  module_id: tree_shake_module.module_id.clone(),
+                                  dep_module_id: dep_module_id.clone(),
+                                  ident: written_imported_ident.ident.clone(),
+                                  is_namespace: true,
+                                  export: field_str.to_string().into(),
+                                },
+                              );
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                crate::statement_graph::ImportSpecifierInfo::Named { local, imported } => {
+                  if local == &written_imported_ident.ident {
+                    let export_str = imported
+                      .as_ref()
+                      .map(|i| i.0.to_string())
+                      .unwrap_or(local.0.to_string());
+
+                    if dep_tree_shake_module
+                      .handled_used_exports
+                      .contains(&UsedExportsIdent::SwcIdent(export_str.clone()))
+                    {
+                      used_stmt_exports
+                        .entry(*stmt_id)
+                        .or_insert_with(HashSet::new)
+                        .insert(UsedStatementIdent::SwcIdent(
+                          written_imported_ident.ident.clone(),
+                        ));
+                    } else {
+                      // we need to trace the dep module to find if the export idents use global variables
+                      write_side_effects_to_trace.push(TraceDepModuleWriteSideEffectsItem {
+                        module_id: tree_shake_module.module_id.clone(),
+                        dep_module_id: dep_module_id.clone(),
+                        ident: written_imported_ident.ident.clone(),
+                        is_namespace: false,
+                        export: export_str.into(),
+                      });
+                    }
+                  }
+                }
+                crate::statement_graph::ImportSpecifierInfo::Default(ident) => {
+                  if ident == &written_imported_ident.ident {
+                    if dep_tree_shake_module
+                      .handled_used_exports
+                      .contains(&UsedExportsIdent::Default)
+                    {
+                      used_stmt_exports
+                        .entry(*stmt_id)
+                        .or_insert_with(HashSet::new)
+                        .insert(UsedStatementIdent::SwcIdent(
+                          written_imported_ident.ident.clone(),
+                        ));
+
+                      write_side_effects_to_trace.push(TraceDepModuleWriteSideEffectsItem {
+                        module_id: tree_shake_module.module_id.clone(),
+                        dep_module_id: dep_module_id.clone(),
+                        ident: written_imported_ident.ident.clone(),
+                        is_namespace: false,
+                        export: "default".to_string().into(),
+                      });
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      tree_shake_modules_to_trace.push((
+        tree_shake_module.module_id.clone(),
+        used_stmt_exports,
+        used_import_all_fields,
+      ));
+    }
+  }
+
+  let mut dep_module_ids = vec![];
+
+  for (module_id, used_stmt_exports, used_import_all_fields) in tree_shake_modules_to_trace {
+    if let Some(tree_shake_module) = tree_shake_modules_map.get_mut(&module_id) {
+      // trace and mark used import statements
+      let traced_import_stmts = tree_shake_module
+        .stmt_graph
+        .trace_and_mark_used_statements(used_stmt_exports, Some(used_import_all_fields));
+
+      let module_ids = set_pending_used_exports(
+        &module_id,
+        module_graph,
+        tree_shake_modules_map,
+        traced_import_stmts,
+      );
+
+      for module_id in module_ids {
+        if !dep_module_ids.contains(&module_id) {
+          dep_module_ids.push(module_id);
+        }
+      }
+    }
+  }
+
+  // handle write side effects when dep module read global variables
+  let write_side_effects_to_trace_map =
+    write_side_effects_to_trace
+      .into_iter()
+      .fold(HashMap::new(), |mut acc, item| {
+        acc
+          .entry(item.dep_module_id.clone())
+          .or_insert_with(Vec::new)
+          .push(item);
+        acc
+      });
+
+  let mut current_module_to_trace = HashMap::new();
+
+  for (dep_module_id, items) in write_side_effects_to_trace_map {
+    for item in items {
+      let is_read_global_var = find_dep_module_read_global_variables_dfs(
+        &dep_module_id,
+        item.export.clone(),
+        tree_shake_modules_map,
+        module_graph,
+        &mut HashSet::default(),
+      );
+
+      if is_read_global_var {
+        if let Some(tree_shake_module) = tree_shake_modules_map.get_mut(&dep_module_id) {
+          tree_shake_module
+            .pending_used_exports
+            .add_used_export(item.export.clone());
+        }
+
+        // trace statements of current current module
+        if let Some(tree_shake_module) = tree_shake_modules_map.get(&item.module_id) {
+          if let Some(stmt_id) = tree_shake_module
+            .stmt_graph
+            .reverse_defined_idents_map
+            .get(&item.ident)
+          {
+            let res = current_module_to_trace
+              .entry(item.module_id)
+              .or_insert((HashMap::default(), HashMap::default()));
+            let used_stmt_exports: &mut HashMap<usize, HashSet<UsedStatementIdent>> = &mut res.0;
+            let used_import_all_fields: &mut HashMap<Id, HashSet<UsedImportAllFields>> = &mut res.1;
+
+            used_stmt_exports
+              .entry(*stmt_id)
+              .or_insert_with(HashSet::new)
+              .insert(UsedStatementIdent::SwcIdent(item.ident.clone()));
+
+            if item.is_namespace {
+              used_import_all_fields
+                .entry(item.ident.clone())
+                .or_insert_with(HashSet::new)
+                .insert(UsedImportAllFields::Ident(item.export.to_string()));
+            }
+          }
+        }
+
+        if !dep_module_ids.contains(&dep_module_id) {
+          dep_module_ids.push(dep_module_id.clone());
+        }
+      }
+    }
+  }
+
+  // trace statements of current current module
+  for (module_id, (used_stmt_exports, used_import_all_fields)) in current_module_to_trace {
+    if let Some(tree_shake_module) = tree_shake_modules_map.get_mut(&module_id) {
+      let traced_import_stmts = tree_shake_module
+        .stmt_graph
+        .trace_and_mark_used_statements(used_stmt_exports, Some(used_import_all_fields));
+
+      let module_ids = set_pending_used_exports(
+        &module_id,
+        module_graph,
+        tree_shake_modules_map,
+        traced_import_stmts,
+      );
+
+      for module_id in module_ids {
+        if !dep_module_ids.contains(&module_id) {
+          dep_module_ids.push(module_id);
+        }
+      }
+    }
+  }
+
+  let mut visited_module_ids = HashSet::default();
+  // trace dep modules
+  traverse_tree_shake_modules(
+    dep_module_ids,
+    module_graph,
+    tree_shake_modules_map,
+    &mut visited_module_ids,
+  );
+
+  visited_module_ids
+}
+
+#[derive(Debug)]
+struct TraceDepModuleWriteSideEffectsItem {
+  pub module_id: ModuleId,
+  pub dep_module_id: ModuleId,
+  pub ident: Id,
+  pub is_namespace: bool,
+  pub export: UsedExportsIdent,
+}
+
+/// Preserve the statements of a dep module that read global variables
+///   For case like:
+/// ```js
+/// import { a } from './src/foo';
+/// a.field = 1;
+/// // in src/foo
+/// export const a = window;
+/// export const b = 1;
+/// ```
+/// We should preserve the statement `a.field = 1;` and remove `b`
+fn find_dep_module_read_global_variables_dfs(
+  dep_module_id: &ModuleId,
+  ident: UsedExportsIdent,
+  tree_shake_modules_map: &HashMap<ModuleId, TreeShakeModule>,
+  module_graph: &ModuleGraph,
+  module_visited: &mut HashSet<ModuleId>,
+) -> bool {
+  if module_visited.contains(dep_module_id) {
+    return false;
+  }
+
+  module_visited.insert(dep_module_id.clone());
+
+  if let Some(tree_shake_module) = tree_shake_modules_map.get(dep_module_id) {
+    // 1. find export statement
+    let stmt_idents =
+      tree_shake_module.used_exports_idents_to_statement_idents(&HashSet::from([ident]));
+    let stmt_used_idents_map = tree_shake_module.get_stmt_used_idents_map(stmt_idents);
+
+    // 2. trace from export statement and find unused statements that read global variables
+    let mut queue = VecDeque::from(
+      stmt_used_idents_map
+        .into_iter()
+        .map(|i| (i.0, i.1, HashMap::default()))
+        .collect::<Vec<_>>(),
+    );
+
+    let mut all_traced_import_stmts = vec![];
+    let mut stmt_visited = HashSet::<StatementId>::default();
+
+    while let Some((stmt_id, used_defined_idents, used_import_all_fields)) = queue.pop_front() {
+      if tree_shake_module.stmt_graph.used_stmts().contains(&stmt_id)
+        || stmt_visited.contains(&stmt_id)
+      {
+        continue;
+      }
+
+      stmt_visited.insert(stmt_id);
+
+      let stmt = tree_shake_module.stmt_graph.stmt(&stmt_id);
+
+      if let StatementSideEffects::ReadTopLevelVar(top_level_vars) = &stmt.side_effects {
+        for top_level_var in top_level_vars {
+          if top_level_var.is_global_var {
+            return true;
+          }
+        }
+      }
+
+      if let Some(import_info) = &stmt.import_info {
+        let traced_import_stmts = TracedUsedImportStatement::from_import_info_and_used_idents(
+          stmt.id,
+          import_info,
+          &used_defined_idents,
+          used_import_all_fields,
+        );
+        all_traced_import_stmts.push(traced_import_stmts);
+      }
+
+      for (dep_stmt, edge) in tree_shake_module.stmt_graph.dependencies(&stmt_id) {
+        let all_used_dep_defined_idents = tree_shake_module
+          .stmt_graph
+          .find_all_used_defined_idents(&stmt_id, dep_stmt, &used_defined_idents, edge);
+
+        queue.push_back((
+          dep_stmt.id,
+          all_used_dep_defined_idents
+            .into_iter()
+            .map(|i| UsedStatementIdent::SwcIdent(i))
+            .collect(),
+          edge.used_import_all_fields.clone(),
+        ));
+      }
+    }
+
+    // 3. trace dep module if another import statement is found
+    for import_stmt in all_traced_import_stmts {
+      let TracedUsedImportStatement {
+        source,
+        used_stmt_idents,
+        kind,
+        ..
+      } = import_stmt;
+      let dep_module_id =
+        module_graph.get_dep_by_source(dep_module_id, source.as_str(), Some(kind));
+
+      if let UsedExports::Partial(used_stmt_idents) = used_stmt_idents {
+        for used_stmt_ident in used_stmt_idents {
+          if find_dep_module_read_global_variables_dfs(
+            &dep_module_id,
+            used_stmt_ident,
+            tree_shake_modules_map,
+            module_graph,
+            module_visited,
+          ) {
+            return true;
+          }
+        }
+      }
+    }
+  }
+
+  false
 }

--- a/crates/plugin_tree_shake/tests/statement_graph.rs
+++ b/crates/plugin_tree_shake/tests/statement_graph.rs
@@ -350,16 +350,19 @@ export { a, b, c as d };"#;
       &SingleThreadedComments::default(),
     );
 
-    let traced_import_stmts = stmt_graph.trace_and_mark_used_statements(HashMap::from([
-      (5, HashSet::from([UsedStatementIdent::Default])),
-      (
-        4,
-        HashSet::from([UsedStatementIdent::SwcIdent((
-          "e".into(),
-          SyntaxContext::from_u32(2),
-        ))]),
-      ),
-    ]));
+    let traced_import_stmts = stmt_graph.trace_and_mark_used_statements(
+      HashMap::from([
+        (5, HashSet::from([UsedStatementIdent::Default])),
+        (
+          4,
+          HashSet::from([UsedStatementIdent::SwcIdent((
+            "e".into(),
+            SyntaxContext::from_u32(2),
+          ))]),
+        ),
+      ]),
+      None,
+    );
 
     assert_eq!(traced_import_stmts.len(), 1);
     assert_eq!(traced_import_stmts[0].stmt_id, 0);
@@ -435,13 +438,16 @@ export { a, b, c as d };"#;
       &SingleThreadedComments::default(),
     );
 
-    let traced_import_stmts = stmt_graph.trace_and_mark_used_statements(HashMap::from([(
-      6,
-      HashSet::from([UsedStatementIdent::SwcIdent((
-        "c".into(),
-        SyntaxContext::from_u32(2),
-      ))]),
-    )]));
+    let traced_import_stmts = stmt_graph.trace_and_mark_used_statements(
+      HashMap::from([(
+        6,
+        HashSet::from([UsedStatementIdent::SwcIdent((
+          "c".into(),
+          SyntaxContext::from_u32(2),
+        ))]),
+      )]),
+      None,
+    );
 
     assert_eq!(traced_import_stmts.len(), 1);
     assert_eq!(traced_import_stmts[0].stmt_id, 0);
@@ -497,7 +503,7 @@ fn trace_and_mark_used_statements_commonjs_exports() {
 
     let mut stmt_graph = StatementGraph::new(&ast, unresolved_mark, top_level_mark, &comments);
 
-    let traced_import_stmts = stmt_graph.trace_and_mark_used_statements(Default::default());
+    let traced_import_stmts = stmt_graph.trace_and_mark_used_statements(Default::default(), None);
 
     assert_eq!(traced_import_stmts.len(), 0);
 
@@ -542,13 +548,16 @@ export const {
       &SingleThreadedComments::default(),
     );
 
-    let traced_import_stmts = stmt_graph.trace_and_mark_used_statements(HashMap::from([(
-      1,
-      HashSet::from([UsedStatementIdent::SwcIdent((
-        "program".into(),
-        SyntaxContext::from_u32(2),
-      ))]),
-    )]));
+    let traced_import_stmts = stmt_graph.trace_and_mark_used_statements(
+      HashMap::from([(
+        1,
+        HashSet::from([UsedStatementIdent::SwcIdent((
+          "program".into(),
+          SyntaxContext::from_u32(2),
+        ))]),
+      )]),
+      None,
+    );
 
     assert_eq!(traced_import_stmts.len(), 1);
     assert_eq!(traced_import_stmts[0].stmt_id, 0);


### PR DESCRIPTION
…writing

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where variables from external packages could be incorrectly removed during tree shaking, ensuring correct preservation in output bundles.

- **New Features**
  - Enhanced tree shaking to more accurately track and retain variables that are written or read at the top level, including those imported from other modules.
  - Improved handling of namespace and default imports/exports in tree shaking scenarios.

- **Tests**
  - Added and updated test cases to verify correct tree shaking behavior for various import/export patterns and side effect scenarios.

- **Refactor**
  - Modularized and clarified the internal logic for tracking used exports and side effects, improving maintainability and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->