### PR TITLE
fix(core): Add origin check to the HMR server

### DIFF
--- a/.changeset/floppy-tires-worry.md
+++ b/.changeset/floppy-tires-worry.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+Added origin validation to HMR server

--- a/.changeset/floppy-tires-worry.md
+++ b/.changeset/floppy-tires-worry.md
@@ -3,3 +3,5 @@
 ---
 
 Added origin validation to HMR server
+
+BREAKING CHANGE: The HMR server now rejects all connections with unrecognized `Origin` headers. Clients need to update their configured ports and hosts if they want external apps to be able to connect to the HMR server.

--- a/packages/core/src/server/ws.ts
+++ b/packages/core/src/server/ws.ts
@@ -66,7 +66,8 @@ export default class WsServer implements IWebSocketServer {
     origins.push(`${protocol}://127.0.0.1:${port}`);
 
     // Add non-localhost origin
-    if (hostname && 
+    if (
+        hostname && 
         hostname.name && 
         hostname.name !== 'localhost' && 
         hostname.name !== '127.0.0.1'

--- a/packages/core/src/server/ws.ts
+++ b/packages/core/src/server/ws.ts
@@ -67,10 +67,10 @@ export default class WsServer implements IWebSocketServer {
 
     // Add non-localhost origin
     if (
-        hostname && 
-        hostname.name && 
-        hostname.name !== 'localhost' && 
-        hostname.name !== '127.0.0.1'
+      hostname && 
+      hostname.name && 
+      hostname.name !== 'localhost' && 
+      hostname.name !== '127.0.0.1'
     ) {
       origins.push(`${protocol}://${hostname.name}:${port}`);
     }

--- a/packages/core/src/server/ws.ts
+++ b/packages/core/src/server/ws.ts
@@ -67,9 +67,9 @@ export default class WsServer implements IWebSocketServer {
 
     // Add non-localhost origin
     if (
-      hostname && 
-      hostname.name && 
-      hostname.name !== 'localhost' && 
+      hostname &&
+      hostname.name &&
+      hostname.name !== 'localhost' &&
       hostname.name !== '127.0.0.1'
     ) {
       origins.push(`${protocol}://${hostname.name}:${port}`);

--- a/packages/core/src/server/ws.ts
+++ b/packages/core/src/server/ws.ts
@@ -57,7 +57,7 @@ export default class WsServer implements IWebSocketServer {
     this.createWebSocketServer();
   }
 
-  private generateHMROrigins(config: NormalizedServerConfig): string[] { {
+  private generateHMROrigins(config: NormalizedServerConfig): string[] {
     const { protocol, hostname, port } = config;
     const origins = [];
         

--- a/packages/core/src/server/ws.ts
+++ b/packages/core/src/server/ws.ts
@@ -60,7 +60,7 @@ export default class WsServer implements IWebSocketServer {
   private generateHMROrigins(config: NormalizedServerConfig): string[] {
     const { protocol, hostname, port } = config;
     const origins = [];
-        
+
     // Add localhost with configured port
     origins.push(`${protocol}://localhost:${port}`);
     origins.push(`${protocol}://127.0.0.1:${port}`);
@@ -68,13 +68,14 @@ export default class WsServer implements IWebSocketServer {
     // Add non-localhost origin
     if (hostname && hostname.name && 
         hostname.name !== 'localhost' && 
-        hostname.name !== '127.0.0.1') {
+        hostname.name !== '127.0.0.1'
+    ) {
       origins.push(`${protocol}://${hostname.name}:${port}`);
     }
-    
+
     return origins;
   }
-  
+
   private createWebSocketServer() {
     try {
       const WebSocketServer = process.versions.bun
@@ -98,7 +99,7 @@ export default class WsServer implements IWebSocketServer {
     if (this.isHMRRequest(request)) {
       this.handleHMRUpgrade(request, socket, head);
     } else {
-      // Close the connection so as to avoid unnecessary system resource utilisation
+      // Close the connection so as to avoid unnecessary system resource utilization
       socket.destroy();
     }
   }

--- a/packages/core/src/server/ws.ts
+++ b/packages/core/src/server/ws.ts
@@ -45,6 +45,7 @@ export default class WsServer implements IWebSocketServer {
   public clientsMap = new WeakMap<WebSocketRawType, WebSocketClient>();
   public bufferedError: any = null;
   public logger: ILogger;
+  private hmrOrigins: string[];
   constructor(
     private httpServer: Server,
     private config: NormalizedServerConfig,
@@ -56,7 +57,7 @@ export default class WsServer implements IWebSocketServer {
     this.createWebSocketServer();
   }
 
-  private generateHMROrigins(config) {
+  private generateHMROrigins(config: NormalizedServerConfig): string[] { {
     const { protocol, hostname, port } = config;
     const origins = [];
         

--- a/packages/core/src/server/ws.ts
+++ b/packages/core/src/server/ws.ts
@@ -66,7 +66,8 @@ export default class WsServer implements IWebSocketServer {
     origins.push(`${protocol}://127.0.0.1:${port}`);
 
     // Add non-localhost origin
-    if (hostname && hostname.name && 
+    if (hostname && 
+        hostname.name && 
         hostname.name !== 'localhost' && 
         hostname.name !== '127.0.0.1'
     ) {
@@ -140,8 +141,8 @@ export default class WsServer implements IWebSocketServer {
   private isHMRRequest(request: IncomingMessage): boolean {
     return (
       request.url === this.config.hmr.path &&
-      request.headers['sec-websocket-protocol'] === HMR_HEADER
-      && this.hmrOrigins.includes(request.headers['origin'])
+      request.headers['sec-websocket-protocol'] === HMR_HEADER &&
+      this.hmrOrigins.includes(request.headers['origin'])
     );
   }
 


### PR DESCRIPTION
**Description:**
Resolves #2168.

**BREAKING CHANGE:** Clients that previously used to connect to Farm's HMR server can no longer do so unless their requests are made from pre-configured origins.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced security for live updates by validating connection origins for WebSocket-based Hot Module Replacement.
- **Bug Fixes**
  - Improved handling of unauthorized WebSocket upgrade requests by closing invalid connections immediately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->