### PR TITLE
fix: delete map file when conifg is 'inline' or 'all-inline'

### DIFF
--- a/.changeset/giant-apples-invite.md
+++ b/.changeset/giant-apples-invite.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+delete map file when conifg is 'inline' or 'all-inline'

--- a/crates/compiler/src/generate/render_resource_pots.rs
+++ b/crates/compiler/src/generate/render_resource_pots.rs
@@ -47,9 +47,10 @@ pub fn render_resource_pots_and_generate_resources(
         resources.lock().push(cached_resource.resource);
 
         if let Some(map) = cached_resource.source_map {
-          resource_pot.add_resource(map.name.clone());
-
-          resources.lock().push(map);
+          if !context.config.sourcemap.is_inline() {
+            resource_pot.add_resource(map.name.clone());
+            resources.lock().push(map);
+          }
         }
       }
     } else {
@@ -145,9 +146,10 @@ pub fn render_resource_pots_and_generate_resources(
             cached_resource.source_map = Some(source_map.clone());
           }
 
-          resource_pot.add_resource(source_map.name.clone());
-
-          resources.lock().push(source_map);
+          if !context.config.sourcemap.is_inline() {
+            resource_pot.add_resource(source_map.name.clone());
+            resources.lock().push(source_map);
+          }
         }
 
         if context.config.persistent_cache.enabled() {

--- a/examples/arco-pro/farm.config.ts
+++ b/examples/arco-pro/farm.config.ts
@@ -9,7 +9,7 @@ export default defineConfig((env) => {
       input: {
         index: './index.html'
       },
-      sourcemap: true,
+      sourcemap: 'inline',
       presetEnv: false,
       concatenateModules: true,
       output: {


### PR DESCRIPTION
Delete useless map file when config is 'inline'
