### PR TITLE
fix: handle Windows long path issue in base64_decode function

### DIFF
--- a/crates/utils/src/hash.rs
+++ b/crates/utils/src/hash.rs
@@ -16,19 +16,19 @@ pub fn base64_encode(bytes: &[u8]) -> String {
 }
 
 pub fn base64_decode(bytes: &[u8]) -> String {
-  // 处理Windows长路径问题：如果解码失败，返回原始字符串的截断版本
+  // Handle Windows long path issue: return safe representation if decode fails
   match general_purpose::STANDARD.decode(bytes) {
     Ok(decoded) => {
-      match String::from_utf8(decoded) {
+      match String::from_utf8(decoded.clone()) {
         Ok(s) => s,
         Err(_) => {
-          // 如果UTF-8转换失败，返回原始字节的安全表示
-          String::from_utf8_lossy(bytes).to_string()
+          // Decoded bytes are not valid UTF-8 - return a lossy UTF-8 view of decoded bytes
+          String::from_utf8_lossy(&decoded).to_string()
         }
       }
     },
     Err(_) => {
-      // 如果base64解码失败（通常是因为路径过长），返回原始字节的安全表示
+      // If base64 decode fails (usually due to long paths), return safe representation of original input
       String::from_utf8_lossy(bytes).to_string()
     }
   }

--- a/crates/utils/src/hash.rs
+++ b/crates/utils/src/hash.rs
@@ -16,7 +16,22 @@ pub fn base64_encode(bytes: &[u8]) -> String {
 }
 
 pub fn base64_decode(bytes: &[u8]) -> String {
-  String::from_utf8(general_purpose::STANDARD.decode(bytes).unwrap()).unwrap()
+  // 处理Windows长路径问题：如果解码失败，返回原始字符串的截断版本
+  match general_purpose::STANDARD.decode(bytes) {
+    Ok(decoded) => {
+      match String::from_utf8(decoded) {
+        Ok(s) => s,
+        Err(_) => {
+          // 如果UTF-8转换失败，返回原始字节的安全表示
+          String::from_utf8_lossy(bytes).to_string()
+        }
+      }
+    },
+    Err(_) => {
+      // 如果base64解码失败（通常是因为路径过长），返回原始字节的安全表示
+      String::from_utf8_lossy(bytes).to_string()
+    }
+  }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
- Replace unwrap() with proper error handling in base64_decode
- Return safe string representation when base64 decode fails
- Fixes InvalidLength panic on Windows with long file paths
- Addresses issue where Farm crashes on Windows due to path length limits

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved error handling for base64 decoding to prevent crashes on invalid input, ensuring a fallback string is always returned.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->