### PR TITLE
chore: test hmr host check

### DIFF
--- a/.changeset/cyan-ligers-hammer.md
+++ b/.changeset/cyan-ligers-hammer.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/cli": patch
+---
+
+Fix #2176 `--base` does not work

--- a/.changeset/witty-plants-fly.md
+++ b/.changeset/witty-plants-fly.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+Fix #2188 lazy compilation should respect publicPath

--- a/crates/plugin_lazy_compilation/src/dynamic_module.ts
+++ b/crates/plugin_lazy_compilation/src/dynamic_module.ts
@@ -123,7 +123,8 @@ if (compilingModules.has(modulePath)) {
       FarmModuleSystem.lazyCompilingQueue = [];
       startLazyCompiling(queue);
       const paths = queue.map((item) => item.modulePath);
-      const url = `/__lazy_compile?paths=${encodeURIComponent(paths.join(','))}&t=${Date.now()}${
+      const lazyCompilationPath = `${FarmModuleSystem.resourceLoader?.publicPaths?.[0] || '/'}__lazy_compile`;
+      const url = `${lazyCompilationPath}?paths=${encodeURIComponent(paths.join(','))}&t=${Date.now()}${
         isNodeLazyCompile ? '&node=true' : ''
       }`;
 

--- a/e2e/vitestSetup.ts
+++ b/e2e/vitestSetup.ts
@@ -114,12 +114,12 @@ export const startProjectAndTest = async (
     const urlRegex =
       /((http|https):\/\/(localhost|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}))(:\d+)?(\/[^\s]*)?/g;
     child.stdout?.on('data', async (chunk) => {
-      result = Buffer.concat([result, chunk]); // 将 chunk 添加到 result 中
+      result = Buffer.concat([result, chunk]);
       const res = result.toString();
       const replacer = res.replace(/\n/g, ' ');
 
       const matches = replacer.match(urlRegex);
-      const pagePath = matches && (matches[1] || matches[0]);
+      const pagePath = matches?.[0]; // use localhost for test
 
       if (pagePath) {
         resolve(pagePath);

--- a/examples/public-path/e2e.spec.ts
+++ b/examples/public-path/e2e.spec.ts
@@ -17,6 +17,14 @@ test(`e2e tests - ${name}`, async () => {
         const root = await page.$('div.public-script');
         const innerHTML = await root?.innerHTML();
         expect(innerHTML).toContain('public script');
+
+        // should load dynamic component
+        await page.waitForSelector('div.farm-container', {
+          timeout: 10000
+        });
+        const container = await page.$('div.farm-container');
+        const containerInnerHTML = await container?.innerHTML();
+        expect(containerInnerHTML).toContain('React + Farm');
       },
       command
     );

--- a/examples/public-path/farm.config.ts
+++ b/examples/public-path/farm.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
       }
     },
     persistentCache: false,
-    treeShaking: true,
+    // treeShaking: true,
     minify: false
   },
   server: {

--- a/examples/public-path/src/components/welcome/index.tsx
+++ b/examples/public-path/src/components/welcome/index.tsx
@@ -81,3 +81,5 @@ export function Welcome() {
     </div>
   );
 }
+
+export default Welcome;

--- a/examples/public-path/src/main.tsx
+++ b/examples/public-path/src/main.tsx
@@ -1,13 +1,16 @@
-import React from 'react';
-import { Welcome } from './components/index';
+import React, { Suspense, lazy } from 'react';
 import './main.css';
 
 console.log(process.env.FARM_BASE_TEST);
 
+const LazyWelcome = lazy(() => import('./components/welcome'));
+
 export function Main() {
   return (
     <>
-      <Welcome />
+      <Suspense fallback={<div>Loading...</div>}>
+        <LazyWelcome />
+      </Suspense>
     </>
   );
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import {
   resolveCore
 } from './utils.js';
 
+import { FarmCLIOptions } from '@farmfe/core';
 import type {
   FarmCLIBuildOptions,
   FarmCLIPreviewOptions,
@@ -56,7 +57,7 @@ cli
       const { root, configPath } = resolveCliConfig(rootPath, options);
       const resolveOptions = resolveCommandOptions(options);
 
-      const defaultOptions = {
+      const defaultOptions: FarmCLIOptions = {
         root,
         compilation: {
           lazyCompilation: options.lazy
@@ -66,6 +67,12 @@ cli
         configPath,
         mode: options.mode
       };
+
+      if (options.base) {
+        defaultOptions.compilation.output = {
+          publicPath: options.base
+        };
+      }
 
       const { start } = await resolveCore();
       handleAsyncOperationErrors(
@@ -146,13 +153,20 @@ cli
       const { root, configPath } = resolveCliConfig(rootPath, options);
 
       const resolveOptions = resolveCommandOptions(options);
-      const defaultOptions = {
+      const defaultOptions: FarmCLIOptions = {
         root,
         mode: options.mode,
         server: resolveOptions,
         configPath,
-        port: options.port
+        port: options.port,
+        clearScreen: options.clearScreen
       };
+
+      if (options.base) {
+        defaultOptions.compilation.output = {
+          publicPath: options.base
+        };
+      }
 
       const { preview } = await resolveCore();
       handleAsyncOperationErrors(

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -588,6 +588,7 @@ export const DEFAULT_DEV_SERVER_OPTIONS: NormalizedServerConfig = {
   https: undefined,
   protocol: 'http',
   hostname: { name: 'localhost', host: undefined },
+  allowedHosts: [],
   host: true,
   proxy: {},
   hmr: DEFAULT_HMR_OPTIONS,

--- a/packages/core/src/config/types.ts
+++ b/packages/core/src/config/types.ts
@@ -34,6 +34,7 @@ export interface UserServerConfig {
   https?: SecureServerOptions;
   protocol?: 'http' | 'https';
   hostname?: { name: string; host: string | undefined };
+  allowedHosts?: string[];
   // http2?: boolean;
   hmr?: boolean | UserHmrConfig;
   proxy?: Record<string, Options>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,7 +74,7 @@ export async function start(
       resolvedUserConfig.compilation.lazyCompilation &&
       typeof resolvedUserConfig.server?.host === 'string'
     ) {
-      await setLazyCompilationDefine(resolvedUserConfig);
+      setLazyCompilationDefine(resolvedUserConfig);
     }
 
     const compiler = await createCompiler(resolvedUserConfig, logger);
@@ -179,7 +179,7 @@ export async function watch(
   const lazyEnabled = resolvedUserConfig.compilation?.lazyCompilation;
 
   if (lazyEnabled) {
-    await setLazyCompilationDefine(resolvedUserConfig);
+    setLazyCompilationDefine(resolvedUserConfig);
   }
 
   const compilerFileWatcher = await createBundleHandler(
@@ -195,7 +195,7 @@ export async function watch(
       logger,
       compiler: compilerFileWatcher.serverOrCompiler as Compiler
     });
-    await devServer.createServer(resolvedUserConfig.server);
+    devServer.createServer(resolvedUserConfig.server);
     devServer.applyMiddlewares([lazyCompilation]);
     await devServer.startServer(resolvedUserConfig.server);
   }
@@ -452,10 +452,8 @@ export function logFileChanges(files: string[], root: string, logger: Logger) {
   );
 }
 
-async function setLazyCompilationDefine(
-  resolvedUserConfig: ResolvedUserConfig
-) {
-  const hostname = await resolveHostname(resolvedUserConfig.server.host);
+function setLazyCompilationDefine(resolvedUserConfig: ResolvedUserConfig) {
+  const hostname = resolveHostname(resolvedUserConfig.server.host);
   resolvedUserConfig.compilation.define = {
     ...(resolvedUserConfig.compilation.define ?? {}),
     FARM_LAZY_COMPILE_SERVER_URL: `${

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -218,12 +218,12 @@ export class Server implements ImplDevServer {
     this._app = new Koa();
   }
 
-  public async createServer(
+  public createServer(
     options: NormalizedServerConfig & UserPreviewServerConfig
   ) {
     const { https, host } = options;
     const protocol = https ? 'https' : 'http';
-    const hostname = await resolveHostname(host);
+    const hostname = resolveHostname(host);
     const publicPath = getValidPublicPath(
       this.compiler?.config.config.output?.publicPath ??
         options?.output.publicPath
@@ -282,7 +282,7 @@ export class Server implements ImplDevServer {
   }
 
   public async createPreviewServer(options: UserPreviewServerConfig) {
-    await this.createServer(options as NormalizedServerConfig);
+    this.createServer(options as NormalizedServerConfig);
 
     this.applyPreviewServerMiddlewares(this.config.middlewares);
 
@@ -296,7 +296,7 @@ export class Server implements ImplDevServer {
       throw new Error('DevServer requires a compiler for development mode.');
     }
 
-    await this.createServer(options);
+    this.createServer(options);
 
     this.hmrEngine = new HmrEngine(this.compiler, this, this.logger);
 
@@ -421,11 +421,7 @@ export class Server implements ImplDevServer {
         : this.config.output.publicPath
     );
 
-    this.resolvedUrls = await resolveServerUrls(
-      this.server,
-      this.config,
-      publicPath
-    );
+    this.resolvedUrls = resolveServerUrls(this.server, this.config, publicPath);
 
     if (this.resolvedUrls) {
       printServerUrls(this.resolvedUrls, this.logger, showPreviewFlag);

--- a/packages/core/src/server/middlewares/lazy-compilation.ts
+++ b/packages/core/src/server/middlewares/lazy-compilation.ts
@@ -16,6 +16,7 @@ import {
 import { Server } from '../index.js';
 
 import { existsSync } from 'node:fs';
+import { getValidPublicPath } from '../../config/normalize-config/normalize-output.js';
 import { logError } from '../error.js';
 
 export function lazyCompilation(devSeverContext: Server): Middleware {
@@ -26,7 +27,11 @@ export function lazyCompilation(devSeverContext: Server): Middleware {
   }
 
   return async (ctx: Context, next: Next) => {
-    if (ctx.path === '/__lazy_compile') {
+    const publicPath = getValidPublicPath(
+      compiler.config.config?.output?.publicPath
+    );
+
+    if (ctx.path === `${publicPath || '/'}__lazy_compile`) {
       const paths = (ctx.query.paths as string).split(',');
       const pathsStr = paths
         .map((p) => {

--- a/packages/core/src/utils/http.ts
+++ b/packages/core/src/utils/http.ts
@@ -36,11 +36,11 @@ export const wildcardHosts = new Set([
   '0000:0000:0000:0000:0000:0000:0000:0000'
 ]);
 
-export async function resolveServerUrls(
+export function resolveServerUrls(
   server: Server,
   options: UserServerConfig,
   publicPath?: string
-): Promise<ResolvedServerUrls> {
+): ResolvedServerUrls {
   const address = server.address();
   const isAddressInfo = (x: any): x is AddressInfo => x?.address;
 
@@ -50,7 +50,7 @@ export async function resolveServerUrls(
 
   const local: string[] = [];
   const network: string[] = [];
-  const hostname = await resolveHostname(options.host);
+  const hostname = resolveHostname(options.host);
   const protocol = options.https ? 'https' : 'http';
   const { port } = getAddressHostnamePort(address);
   const base = publicPath || '';
@@ -88,9 +88,9 @@ export async function resolveServerUrls(
   return { local, network };
 }
 
-export async function resolveHostname(
+export function resolveHostname(
   optionsHost: string | boolean | undefined
-): Promise<Hostname> {
+): Hostname {
   let host: string | undefined;
   if (optionsHost === undefined || optionsHost === false) {
     host = 'localhost';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced WebSocket server handling for hot module replacement with improved origin validation and support for multiple allowed hosts.
  - Simplified server URL and hostname resolution by making related functions synchronous.
  - Adjusted lazy compilation and middleware to respect dynamic public paths and configuration.
- **Bug Fixes**
  - Fixed the `--base` option to correctly propagate the public path in CLI commands.
  - Ensured lazy compilation respects the configured public path.
- **New Features**
  - Added support for specifying allowed hosts in server configuration to broaden accepted origins for HMR requests.
- **Improvements**
  - Updated component loading to use lazy loading with fallback UI for better performance and user experience.
  - Extended test coverage to verify dynamic component loading in different modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->