### PR TITLE
fix: incorrect publicPath when isolating farm runtime

### DIFF
--- a/.changeset/old-pens-juggle.md
+++ b/.changeset/old-pens-juggle.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+Fix incorrect publicPath when isolating farm runtime

--- a/.changeset/wet-seas-buy.md
+++ b/.changeset/wet-seas-buy.md
@@ -1,0 +1,5 @@
+---
+"create-farm-plugin": patch
+---
+
+Lock cargo-xwin to 0.18.6

--- a/.github/workflows/rust-build.yaml
+++ b/.github/workflows/rust-build.yaml
@@ -61,7 +61,7 @@ jobs:
             target: i686-pc-windows-msvc
             build: |
               export CARGO_PROFILE_RELEASE_LTO=false
-              cargo install cargo-xwin --locked
+              cargo install cargo-xwin@0.18.6 --locked
               cd packages/core && npm run build:rs -- --target i686-pc-windows-msvc --cargo-flags="--no-default-features"
               cd ../create-farm && npm run build -- --target i686-pc-windows-msvc
               cd ../../rust-plugins/react && npm run build -- --target i686-pc-windows-msvc --abi win32-ia32-msvc
@@ -72,7 +72,7 @@ jobs:
             build: |
               export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256
               export CARGO_PROFILE_RELEASE_LTO=false
-              cargo install cargo-xwin --locked
+              cargo install cargo-xwin@0.18.6 --locked
               cd packages/core && npm run build:rs -- --target aarch64-pc-windows-msvc --cargo-flags="--no-default-features"
               cd ../create-farm && npm run build -- --target aarch64-pc-windows-msvc
               cd ../../rust-plugins/react && npm run build -- --target aarch64-pc-windows-msvc --abi win32-arm64-msvc

--- a/crates/plugin_html/src/absolute_path_handler.rs
+++ b/crates/plugin_html/src/absolute_path_handler.rs
@@ -18,23 +18,14 @@ impl VisitMut for AbsolutePathHandler {
   fn visit_mut_element(&mut self, element: &mut Element) {
     if matches!(element.tag_name.to_lowercase().as_str(), "script" | "link") {
       for attr in &mut element.attributes {
+        let value = attr.value.clone().unwrap_or_default();
         // determine if the path start with /.
         if matches!(attr.name.to_lowercase().as_str(), "src" | "href")
-          && !attr
-            .value
-            .clone()
-            .unwrap_or_default()
-            .starts_with(&self.public_path)
-          && attr.value.clone().unwrap_or_default().starts_with("/")
+          && !value.starts_with(&self.public_path)
+          && value.starts_with("/")
         {
-          attr.value = Some(
-            format!(
-              "{}{}",
-              self.public_path,
-              attr.value.clone().unwrap_or_default()
-            )
-            .into(),
-          );
+          let normalized_value = value.trim_start_matches("/");
+          attr.value = Some(format!("{}{}", self.public_path, normalized_value).into());
         }
       }
     }

--- a/crates/plugin_html/src/absolute_path_handler.rs
+++ b/crates/plugin_html/src/absolute_path_handler.rs
@@ -33,7 +33,6 @@ impl VisitMut for AbsolutePathHandler {
               self.public_path,
               attr.value.clone().unwrap_or_default()
             )
-            .replace("//", "/")
             .into(),
           );
         }

--- a/crates/plugin_html/src/resources_injector.rs
+++ b/crates/plugin_html/src/resources_injector.rs
@@ -91,7 +91,11 @@ impl<'a> ResourcesInjector<'a> {
         &self.already_injected_resources,
       );
 
-      let script_element = create_element("script", None, vec![("src", &format!("/{name}"))]);
+      let script_element = create_element(
+        "script",
+        None,
+        vec![("src", &format!("{}{}", self.options.public_path, name))],
+      );
       element.children.push(Child::Element(script_element));
 
       if let Some(resource) = resource {
@@ -132,7 +136,7 @@ impl<'a> ResourcesInjector<'a> {
       element.children.push(Child::Element(create_element(
         "script",
         None,
-        vec![("src", &format!("/{}", name))],
+        vec![("src", &format!("{}{}", self.options.public_path, name))],
       )));
 
       if let Some(resource) = resource {
@@ -171,7 +175,7 @@ impl<'a> ResourcesInjector<'a> {
       element.children.push(Child::Element(create_element(
         "script",
         None,
-        vec![("src", &format!("/{name}"))],
+        vec![("src", &format!("{}{}", self.options.public_path, name))],
       )));
 
       if let Some(resource) = resource {
@@ -207,7 +211,7 @@ impl<'a> ResourcesInjector<'a> {
       element.children.push(Child::Element(create_element(
         "script",
         None,
-        vec![("src", &format!("/{name}"))],
+        vec![("src", &format!("{}{}", self.options.public_path, name))],
       )));
       if let Some(resource) = resource {
         self.additional_inject_resources.push(resource);
@@ -279,7 +283,7 @@ impl<'a> ResourcesInjector<'a> {
     element.children.push(Child::Element(create_element(
       "script",
       None,
-      vec![("src", &format!("/{name}"))],
+      vec![("src", &format!("{}{}", self.options.public_path, name))],
     )));
 
     if let Some(resource) = resource {

--- a/packages/create-farm-plugin/templates/rust/.github/workflows/build.yaml
+++ b/packages/create-farm-plugin/templates/rust/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
             target: i686-pc-windows-msvc
             build: |
               export CARGO_PROFILE_RELEASE_LTO=false
-              cargo install --locked cargo-xwin
+              cargo install --locked cargo-xwin@0.18.6
               npm run build -- --target i686-pc-windows-msvc --abi win32-ia32-msvc --cargo-flags="--no-default-features"
           - os: windows-latest
             abi: win32-arm64-msvc
@@ -47,7 +47,7 @@ jobs:
             build: |
               export CARGO_PROFILE_RELEASE_CODEGEN_UNITS=256
               export CARGO_PROFILE_RELEASE_LTO=false
-              cargo install --locked cargo-xwin
+              cargo install --locked cargo-xwin@0.18.6
               npm run build -- --target aarch64-pc-windows-msvc --abi win32-arm64-msvc --cargo-flags="--no-default-features"
           # linux
           - os: ubuntu-latest


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the handling of the public path configuration when isolating the runtime, ensuring resources are loaded from the correct location.
  - Updated resource injection so that script URLs now use the configured public path instead of a fixed root path.
  - Adjusted path concatenation logic to remove leading slashes before combining with the public path for normalized URLs.
- **Chores**
  - Pinned the version of the cargo-xwin tool to 0.18.6 in Windows cross-compilation build workflows for consistent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->