### PR TITLE
chore: support output.asciiOnly

### DIFF
--- a/.changeset/early-ghosts-deny.md
+++ b/.changeset/early-ghosts-deny.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+Support `output.asciiOnly`

--- a/crates/core/src/config/custom.rs
+++ b/crates/core/src/config/custom.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use serde::{de::DeserializeOwned, Deserialize};
+use serde::{de::DeserializeOwned};
 
 use crate::context::CompilationContext;
 
@@ -17,6 +17,7 @@ pub const CUSTOM_CONFIG_EXTERNAL_RECORD: &str = "external.record";
 pub const CUSTOM_CONFIG_RESOLVE_DEDUPE: &str = "resolve.dedupe";
 pub const CUSTOM_CONFIG_CSS_MODULES_LOCAL_CONVERSION: &str = "css.modules.locals_conversion";
 pub const CUSTOM_CONFIG_ASSETS_MODE: &str = "assets.mode";
+pub const CUSTOM_OUTPUT_ASCII_ONLY: &str = "output.ascii_only";
 
 pub fn get_config_runtime_isolate(context: &Arc<CompilationContext>) -> bool {
   if let Some(val) = context.config.custom.get(CUSTOM_CONFIG_RUNTIME_ISOLATE) {
@@ -63,6 +64,14 @@ pub fn get_config_css_modules_local_conversion(config: &Config) -> NameConversio
 
 pub fn get_config_assets_mode(config: &Config) -> Option<AssetFormatMode> {
   get_field_or_default_from_custom(config, CUSTOM_CONFIG_ASSETS_MODE)
+}
+
+pub fn get_config_output_ascii_only(config: &Config) -> bool {
+  if let Some(val) = config.custom.get(CUSTOM_OUTPUT_ASCII_ONLY) {
+    val == "true"
+  } else {
+    false
+  }
 }
 
 fn get_field_or_default_from_custom<T: Default + DeserializeOwned>(

--- a/crates/plugin_bundle/src/resource_pot_to_bundle/bundle/bundle_analyzer.rs
+++ b/crates/plugin_bundle/src/resource_pot_to_bundle/bundle/bundle_analyzer.rs
@@ -21,7 +21,7 @@ use farmfe_core::{
 };
 use farmfe_toolkit::{
   common::build_source_map,
-  script::{codegen_module, swc_try_with::try_with, CodeGenCommentsConfig},
+  script::{codegen_module, create_codegen_config, swc_try_with::try_with, CodeGenCommentsConfig},
   swc_ecma_transforms::fixer,
   swc_ecma_visit::VisitMutWith,
 };
@@ -1025,14 +1025,13 @@ impl<'a> BundleAnalyzer<'a> {
       let mut mappings = vec![];
       let code_bytes = codegen_module(
         &module_analyzer.ast,
-        self.context.config.script.target,
         module_analyzer.cm.clone(),
         if sourcemap_enabled {
           Some(&mut mappings)
         } else {
           None
         },
-        false,
+        create_codegen_config(&self.context).with_minify(false),
         Some(CodeGenCommentsConfig {
           comments: &comments,
           config: &self.context.config.comments,

--- a/crates/plugin_css/src/lib.rs
+++ b/crates/plugin_css/src/lib.rs
@@ -5,7 +5,9 @@ use std::{path::PathBuf, sync::Arc};
 
 use dep_analyzer::DepAnalyzer;
 use farmfe_core::config::css::NameConversion;
-use farmfe_core::config::custom::get_config_css_modules_local_conversion;
+use farmfe_core::config::custom::{
+  get_config_css_modules_local_conversion, get_config_output_ascii_only,
+};
 use farmfe_core::config::minify::MinifyOptions;
 use farmfe_core::module::CommentsMetaData;
 use farmfe_core::{
@@ -594,6 +596,7 @@ impl Plugin for FarmPluginCss {
             None
           },
           context.config.minify.enabled(),
+          get_config_output_ascii_only(&context.config),
         );
 
         rendered_modules.lock().push(RenderedModule {

--- a/crates/plugin_css/src/transform_css_to_script.rs
+++ b/crates/plugin_css/src/transform_css_to_script.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use farmfe_core::{
   cache::cache_store::CacheStoreKey,
+  config::custom::get_config_output_ascii_only,
   context::CompilationContext,
   deserialize,
   enhanced_magic_string::collapse_sourcemap::{collapse_sourcemap_chain, CollapseSourcemapOptions},
@@ -103,6 +104,7 @@ pub fn transform_css_to_script_modules(
           None
         },
         context.config.minify.enabled(),
+        get_config_output_ascii_only(&context.config),
       );
       let mut source_map_chain = m.source_map_chain.clone();
       drop(module_graph);

--- a/crates/plugin_minify/src/exports_minifier.rs
+++ b/crates/plugin_minify/src/exports_minifier.rs
@@ -207,8 +207,7 @@ export { long10 } from './dep2';
     try_with(cm.clone(), &Globals::new(), || {
       ast.visit_mut_with(&mut export_minifier);
 
-      let code_bytes =
-        codegen_module(&mut ast, EsVersion::latest(), cm, None, false, None).unwrap();
+      let code_bytes = codegen_module(&mut ast, cm, None, Default::default(), None).unwrap();
       let code = String::from_utf8(code_bytes).unwrap();
 
       println!("{code}");

--- a/crates/plugin_minify/src/imports_minifier.rs
+++ b/crates/plugin_minify/src/imports_minifier.rs
@@ -713,8 +713,7 @@ export { hello1, hello2, default as world1 } from './dep';
 
       ast.visit_mut_with(&mut imports_minifier);
 
-      let code_bytes =
-        codegen_module(&mut ast, EsVersion::latest(), cm, None, false, None).unwrap();
+      let code_bytes = codegen_module(&mut ast, cm, None, Default::default(), None).unwrap();
       let code = String::from_utf8(code_bytes).unwrap();
 
       println!("{code}");

--- a/crates/plugin_minify/src/minify_resource_pot.rs
+++ b/crates/plugin_minify/src/minify_resource_pot.rs
@@ -1,7 +1,7 @@
 use std::{path::PathBuf, sync::Arc};
 
 use farmfe_core::{
-  config::minify::MinifyOptions,
+  config::{custom::get_config_output_ascii_only, minify::MinifyOptions},
   context::CompilationContext,
   error::Result,
   resource::resource_pot::ResourcePot,
@@ -14,8 +14,8 @@ use farmfe_toolkit::{
   css::{codegen_css_stylesheet, parse_css_stylesheet, ParseCssModuleResult},
   minify::config::NormalizedMinifyOptions,
   script::{
-    codegen_module, parse_module, swc_try_with::try_with, CodeGenCommentsConfig,
-    ParseScriptModuleResult,
+    codegen_module, create_codegen_config, parse_module, swc_try_with::try_with,
+    CodeGenCommentsConfig, ParseScriptModuleResult,
   },
   swc_css_minifier::minify,
   swc_ecma_minifier::{optimize, option::ExtraOptions},
@@ -81,14 +81,13 @@ pub fn minify_js(
 
     let minified_content = codegen_module(
       &ast,
-      context.config.script.target.clone(),
       cm.clone(),
       if sourcemap_enabled {
         Some(&mut src_map)
       } else {
         None
       },
-      context.config.minify.enabled(),
+      create_codegen_config(context),
       Some(CodeGenCommentsConfig {
         comments: &comments,
         config: &context.config.comments,
@@ -143,6 +142,7 @@ pub fn minify_css(resource_pot: &mut ResourcePot, context: &Arc<CompilationConte
         None
       },
       context.config.minify.enabled(),
+      get_config_output_ascii_only(&context.config),
     );
 
     resource_pot.meta.rendered_content = Arc::new(minified_content);

--- a/crates/plugin_runtime/src/render_resource_pot/render_module.rs
+++ b/crates/plugin_runtime/src/render_resource_pot/render_module.rs
@@ -12,7 +12,7 @@ use farmfe_toolkit::{
   common::{build_source_map, create_swc_source_map, MinifyBuilder, Source},
   minify::minify_js_module,
   script::{
-    codegen_module,
+    codegen_module, create_codegen_config,
     swc_try_with::{resolve_module_mark, try_with},
     CodeGenCommentsConfig,
   },
@@ -168,14 +168,13 @@ pub fn render_module<'a, F: Fn(&ModuleId) -> bool>(
   let mut mappings = vec![];
   let code_bytes = codegen_module(
     &cloned_module,
-    context.config.script.target.clone(),
     cm.clone(),
     if sourcemap_enabled {
       Some(&mut mappings)
     } else {
       None
     },
-    context.config.minify.enabled(),
+    create_codegen_config(context),
     Some(CodeGenCommentsConfig {
       comments: &comments,
       // preserve all comments when generate module code.

--- a/crates/plugin_runtime/src/render_resource_pot/transform_async_module.rs
+++ b/crates/plugin_runtime/src/render_resource_pot/transform_async_module.rs
@@ -249,10 +249,9 @@ mod tests {
     String::from_utf8(
       farmfe_toolkit::script::codegen_module(
         ast,
-        EsVersion::EsNext,
         Arc::new(SourceMap::new(FilePathMapping::empty())),
         None,
-        false,
+        Default::default(),
         None,
       )
       .unwrap(),

--- a/crates/plugin_runtime/src/render_resource_pot/transform_module_decls.rs
+++ b/crates/plugin_runtime/src/render_resource_pot/transform_module_decls.rs
@@ -970,8 +970,7 @@ export * from './e';
         },
       );
 
-      let code_bytes =
-        codegen_module(&mut ast, EsVersion::latest(), cm, None, false, None).unwrap();
+      let code_bytes = codegen_module(&mut ast, cm, None, Default::default(), None).unwrap();
       let code = String::from_utf8(code_bytes).unwrap();
 
       println!("{code}");
@@ -1069,8 +1068,7 @@ export const f = 1, h = 2;
         },
       );
 
-      let code_bytes =
-        codegen_module(&mut ast, EsVersion::latest(), cm, None, false, None).unwrap();
+      let code_bytes = codegen_module(&mut ast, cm, None, Default::default(), None).unwrap();
       let code = String::from_utf8(code_bytes).unwrap();
 
       println!("{code}");

--- a/crates/plugin_tree_shake/tests/remove_useless_stmts.rs
+++ b/crates/plugin_tree_shake/tests/remove_useless_stmts.rs
@@ -9,7 +9,6 @@ use farmfe_core::{
   module::module_graph::{ModuleGraph, ModuleGraphEdge, ModuleGraphEdgeDataItem},
   plugin::ResolveKind,
   swc_common::{Globals, GLOBALS},
-  swc_ecma_ast::EsVersion,
 };
 use farmfe_plugin_tree_shake::{
   module::{TreeShakeModule, UsedExports, UsedExportsIdent},
@@ -86,7 +85,7 @@ export default 'default';
     let module = module_graph.module(&module_id).unwrap();
     let swc_module = &module.meta.as_script().ast;
 
-    let bytes = codegen_module(swc_module, EsVersion::EsNext, cm, None, false, None).unwrap();
+    let bytes = codegen_module(swc_module, cm, None, Default::default(), None).unwrap();
     let result = String::from_utf8(bytes).unwrap();
     println!("{result}");
     let expect = r#"import { aValue } from './foo';
@@ -148,7 +147,7 @@ export * from './src/foo';
     let module = module_graph.module(&module_id).unwrap();
     let swc_module = &module.meta.as_script().ast;
 
-    let bytes = codegen_module(swc_module, EsVersion::EsNext, cm, None, false, None).unwrap();
+    let bytes = codegen_module(swc_module, cm, None, Default::default(), None).unwrap();
     let result = String::from_utf8(bytes).unwrap();
     assert_eq!(
       result,
@@ -203,7 +202,7 @@ export * from './src/bar';
     let module = module_graph.module(&module_id).unwrap();
     let swc_module = &module.meta.as_script().ast;
 
-    let bytes = codegen_module(swc_module, EsVersion::EsNext, cm, None, false, None).unwrap();
+    let bytes = codegen_module(swc_module, cm, None, Default::default(), None).unwrap();
     let result = String::from_utf8(bytes).unwrap();
     assert_eq!(
       result,
@@ -266,7 +265,7 @@ fn remove_useless_stmts_nested_defined_idents() {
     let module = module_graph.module(&module_id).unwrap();
     let swc_module = &module.meta.as_script().ast;
 
-    let bytes = codegen_module(swc_module, EsVersion::EsNext, cm, None, false, None).unwrap();
+    let bytes = codegen_module(swc_module, cm, None, Default::default(), None).unwrap();
     let result = String::from_utf8(bytes).unwrap();
 
     let expect = r#"import { a, invalidate } from './dep';
@@ -333,7 +332,7 @@ fn trace_loadable_esm() {
         .meta
         .as_script()
         .ast;
-      let code_bytes = codegen_module(ast, EsVersion::EsNext, cm, None, false, None).unwrap();
+      let code_bytes = codegen_module(ast, cm, None, Default::default(), None).unwrap();
       let code = String::from_utf8(code_bytes).unwrap();
 
       let output_path = PathBuf::from(file).parent().unwrap().join("output.js");
@@ -393,7 +392,7 @@ fn trace_complex_decl_stmt() {
       .meta
       .as_script()
       .ast;
-    let code_bytes = codegen_module(ast, EsVersion::EsNext, cm, None, false, None).unwrap();
+    let code_bytes = codegen_module(ast, cm, None, Default::default(), None).unwrap();
     let code = String::from_utf8(code_bytes).unwrap();
 
     assert_eq!(code.replace("\r\n", "\n"), r#"import { h, BaseTransition, BaseTransitionPropsValidators } from '@vue/runtime-core';

--- a/crates/swc_transformer_import_glob/tests/mod.rs
+++ b/crates/swc_transformer_import_glob/tests/mod.rs
@@ -161,7 +161,7 @@ fn test_import_meta_glob() {
     )
     .unwrap();
 
-    let code = codegen_module(&ast, EsVersion::EsNext, cm, None, false, None).unwrap();
+    let code = codegen_module(&ast, cm, None, Default::default(), None).unwrap();
     let code = String::from_utf8(code).unwrap();
 
     let expected_file = file.with_extension("expected.js");

--- a/crates/toolkit/src/css/mod.rs
+++ b/crates/toolkit/src/css/mod.rs
@@ -139,7 +139,7 @@ pub fn escape_non_ascii(s: &str) -> String {
       if c.is_ascii() {
         c.to_string()
       } else {
-        format!("\\{:x}", c as u32)
+        format!("\\{:06x}", c as u32)
       }
     })
     .collect()

--- a/crates/toolkit/src/script/mod.rs
+++ b/crates/toolkit/src/script/mod.rs
@@ -7,7 +7,7 @@ use swc_ecma_codegen::{
 use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax, TsConfig};
 
 use farmfe_core::{
-  config::{comments::CommentsConfig, ScriptParserConfig},
+  config::{comments::CommentsConfig, custom::get_config_output_ascii_only, ScriptParserConfig},
   context::CompilationContext,
   error::{CompilationError, Result},
   module::{ModuleSystem, ModuleType},
@@ -107,6 +107,18 @@ pub struct CodeGenCommentsConfig<'a> {
   pub config: &'a CommentsConfig,
 }
 
+pub fn create_codegen_config(context: &CompilationContext) -> swc_ecma_codegen::Config {
+  let minify = context.config.minify.enabled();
+  let target = context.config.script.target.clone();
+  let ascii_only = get_config_output_ascii_only(&context.config);
+
+  swc_ecma_codegen::Config::default()
+    .with_minify(minify)
+    .with_target(target)
+    .with_ascii_only(ascii_only)
+    .with_omit_last_semi(true)
+}
+
 /// ast codegen, return generated utf8 bytes. using [String::from_utf8] if you want to transform the bytes to string.
 /// Example:
 /// ```ignore
@@ -115,21 +127,20 @@ pub struct CodeGenCommentsConfig<'a> {
 /// ```
 pub fn codegen_module(
   ast: &SwcModule,
-  target: EsVersion,
   cm: Arc<SourceMap>,
   src_map: Option<&mut Vec<(BytePos, LineCol)>>,
-  minify: bool,
+  codegen_config: swc_ecma_codegen::Config,
   comments_cfg: Option<CodeGenCommentsConfig>,
 ) -> std::result::Result<Vec<u8>, std::io::Error> {
   let mut buf = vec![];
 
   {
     let wr = Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, src_map)) as Box<dyn WriteJs>;
-    let cfg = swc_ecma_codegen::Config::default()
-      .with_minify(minify)
-      .with_target(target)
-      .with_omit_last_semi(true)
-      .with_ascii_only(false);
+    // let cfg = swc_ecma_codegen::Config::default()
+    //   .with_minify(minify)
+    //   .with_target(target)
+    //   .with_omit_last_semi(true)
+    //   .with_ascii_only(false);
 
     if let Some(comments_cfg) = &comments_cfg {
       minify_comments(comments_cfg.comments, comments_cfg.config);
@@ -138,7 +149,7 @@ pub fn codegen_module(
     let comments = comments_cfg.map(|c| c.comments as &dyn Comments);
 
     let mut emitter = Emitter {
-      cfg,
+      cfg: codegen_config,
       comments,
       cm,
       wr,

--- a/crates/toolkit/tests/script.rs
+++ b/crates/toolkit/tests/script.rs
@@ -30,10 +30,9 @@ fn parse_and_codegen_module() {
 
     let bytes = codegen_module(
       &ast,
-      Default::default(),
       cm,
       None,
-      false,
+      swc_ecma_codegen::Config::default(),
       Some(CodeGenCommentsConfig {
         comments: &comments,
         config: &CommentsConfig::default(),

--- a/examples/less/farm.config.ts
+++ b/examples/less/farm.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
     },
     output: {
       path: './build',
+      asciiOnly: true,
     },
     sourcemap: false,
     persistentCache: false,

--- a/examples/less/src/components/welcome/index.tsx
+++ b/examples/less/src/components/welcome/index.tsx
@@ -12,13 +12,13 @@ export function Welcome() {
     <div className="farm-container">
       <img className="logo" src={logo} alt="" />
       <FarmCard>
-        <div className="main-desc">
+        <div className="main-desc description">
           <h2 className="main-sub-title">
             Get started With
             <span className="main-content"> React + Farm + Less</span>
           </h2>
-          <span className="main-content">
-            Super fast web building tool written in Rust.
+          <span className="main-content description">
+            Super fast web building tool written in Rust. 基于 Rust 的极速 Web 构建工具。
           </span>
         </div>
       </FarmCard>

--- a/examples/less/src/index.less
+++ b/examples/less/src/index.less
@@ -6,6 +6,12 @@
   .description {
     &:hover {
       color: @hoverColor;
+
+      &:before {
+        content: "中文";
+        color: gold;
+        margin-right: 4px;
+      }
     }
   }
 }

--- a/examples/less/src/index.less
+++ b/examples/less/src/index.less
@@ -8,7 +8,7 @@
       color: @hoverColor;
 
       &:before {
-        content: "中文";
+        content: "中文123";
         color: gold;
         margin-right: 4px;
       }

--- a/packages/core/src/config/constants.ts
+++ b/packages/core/src/config/constants.ts
@@ -14,7 +14,8 @@ export const CUSTOM_KEYS = {
   runtime_isolate: 'runtime.isolate',
   resolve_dedupe: 'resolve.dedupe',
   css_locals_conversion: 'css.modules.locals_conversion',
-  assets_mode: 'assets.mode'
+  assets_mode: 'assets.mode',
+  output_ascii_only: 'output.ascii_only'
 };
 
 export const FARM_RUST_PLUGIN_FUNCTION_ENTRY = 'func.js';

--- a/packages/core/src/config/normalize-config/normalize-output.ts
+++ b/packages/core/src/config/normalize-config/normalize-output.ts
@@ -9,6 +9,7 @@ import {
   mapTargetEnvValue,
   normalizeBasePath
 } from '../../utils/share.js';
+import { CUSTOM_KEYS } from '../constants.js';
 import { ResolvedCompilation } from '../types.js';
 
 export function normalizeOutput(
@@ -36,6 +37,11 @@ export function normalizeOutput(
   if (config.output.clean === undefined) {
     config.output.clean = true;
   }
+
+  config.custom = {
+    ...(config.custom || {}),
+    [CUSTOM_KEYS.output_ascii_only]: `${!!config.output.asciiOnly}`
+  };
 
   // only set default polyfill in production
   if (isProduction) {

--- a/packages/core/src/config/schema.ts
+++ b/packages/core/src/config/schema.ts
@@ -51,7 +51,8 @@ const compilationConfigSchema = z
           ])
           .optional(),
         format: z.enum(['cjs', 'esm']).optional(),
-        clean: z.boolean().optional()
+        clean: z.boolean().optional(),
+        asciiOnly: z.boolean().optional()
       })
       .strict()
       .optional(),

--- a/packages/core/src/types/binding.ts
+++ b/packages/core/src/types/binding.ts
@@ -160,6 +160,12 @@ export interface OutputConfig {
    * clean output.path automatically or not
    */
   clean?: boolean;
+
+  /**
+   * output ascii only
+   * @default false
+   */
+  asciiOnly?: boolean;
 }
 
 export interface ResolveConfig {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for an ASCII-only output option, enabling all non-ASCII characters in build outputs to be escaped as Unicode sequences.
  * Introduced a configuration setting (`asciiOnly`) for output, accessible in configuration files and schemas.

* **Enhancements**
  * Updated CSS and JavaScript code generation to honor the ASCII-only output setting.
  * Improved hover styling in example components with added visual feedback and multilingual description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->