### PR TITLE
fix: add `@vue/tsconfig` for vue3 template

### DIFF
--- a/crates/create-farm-rs/templates/vue3/package.json
+++ b/crates/create-farm-rs/templates/vue3/package.json
@@ -15,6 +15,7 @@
     "@farmfe/cli": "^1.0.4",
     "@farmfe/core": "^1.6.7",
     "@vitejs/plugin-vue": "5.0.4",
+    "@vue/tsconfig": "^0.7.0",
     "core-js": "^3.30.1"
   }
 }

--- a/crates/create-farm-rs/templates/vue3/tsconfig.json
+++ b/crates/create-farm-rs/templates/vue3/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,


### PR DESCRIPTION
#2204 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Vue 3 template to include the latest recommended TypeScript configuration for Vue by adding a new development dependency and extending the base TypeScript config.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->