### PR TITLE
fix: windows hmr syntax error

### DIFF
--- a/.changeset/quick-snakes-heal.md
+++ b/.changeset/quick-snakes-heal.md
@@ -1,0 +1,6 @@
+---
+"@farmfe/runtime-plugin-hmr": patch
+"@farmfe/core": patch
+---
+
+Fix HMR panic on windows when there are syntax errors

--- a/crates/compiler/src/update/handle_update_modules.rs
+++ b/crates/compiler/src/update/handle_update_modules.rs
@@ -230,13 +230,20 @@ fn resolve_watch_graph_paths(
 
 fn resolve_last_failed_module_paths(
   mut paths: Vec<(String, UpdateType)>,
-  last_fail_module_ids: &[ModuleId],
+  last_failed_module_ids: &[ModuleId],
   context: &Arc<CompilationContext>,
 ) -> Vec<(String, UpdateType)> {
+  let paths_ids = paths
+    .iter()
+    .map(|(p, _)| ModuleId::new(p, "", &context.config.root))
+    .collect::<Vec<_>>();
+
+  let last_failed_module_ids = last_failed_module_ids
+    .iter()
+    .filter(|id| !paths_ids.contains(id));
+
   paths.extend(
-    last_fail_module_ids
-      .iter()
-      .map(|id| (id.resolved_path(&context.config.root), UpdateType::Updated)),
+    last_failed_module_ids.map(|id| (id.resolved_path(&context.config.root), UpdateType::Updated)),
   );
 
   paths

--- a/e2e/vitestSetup.ts
+++ b/e2e/vitestSetup.ts
@@ -49,7 +49,7 @@ const visitPage = async (
     page?.on('console', (msg) => {
       const lowerCaseMsg = msg.text().toLocaleLowerCase();
 
-      if (msg.type() === 'error' && !lowerCaseMsg.includes('warn') && !lowerCaseMsg.includes('warning')) {
+      if (msg.type() === 'error' && !lowerCaseMsg.includes('warn') && !lowerCaseMsg.includes('warning') && !/Parse `.+` failed/.test(msg.text())) {
         logger(`command ${command} ${examplePath} -> ${path}: ${msg.text()}`, {
           color: 'red'
         });

--- a/examples/react-fast-refresh/src/index.tsx
+++ b/examples/react-fast-refresh/src/index.tsx
@@ -6,3 +6,5 @@ const container = document.querySelector("#root");
 const root = createRoot(container!);
 
 root.render(<Main />);
+
+const a = 123;

--- a/packages/runtime-plugin-hmr/src/overlay.ts
+++ b/packages/runtime-plugin-hmr/src/overlay.ts
@@ -671,7 +671,7 @@ export class ErrorOverlay extends HTMLElement {
 
       const splitMessage = splitErrorMessage(msg);
 
-      console.error(splitMessage.errorInfo);
+      console.error(`[Farm HMR] ${splitMessage.errorInfo}`);
 
       if (splitMessage.codeBlocks && splitMessage.codeBlocks.length > 0) {
         splitMessage.codeBlocks.forEach((codeBlock, blockIndex) => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents HMR crashes on Windows when syntax errors occur.
  - HMR update failures no longer terminate the process; errors are sent to clients and logged safely.
  - Clearer error messages in the overlay with a “[Farm HMR]” prefix.

- Tests
  - Added end-to-end tests verifying HMR error display and recovery after fixing syntax errors.

- Chores
  - Patch release bumps for @farmfe/runtime-plugin-hmr and @farmfe/core to deliver stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->