### PR TITLE
feat: support css.transformToScript

### DIFF
--- a/.changeset/weak-files-hide.md
+++ b/.changeset/weak-files-hide.md
@@ -1,0 +1,5 @@
+---
+"@farmfe/core": patch
+---
+
+Feat(core): support css.transformToScript

--- a/crates/core/src/config/css.rs
+++ b/crates/core/src/config/css.rs
@@ -33,6 +33,29 @@ pub struct CssPrefixerConfig {
 pub struct CssConfig {
   pub modules: Option<CssModulesConfig>,
   pub prefixer: Option<CssPrefixerConfig>,
+  /// transform css module to script module, for example:
+  ///
+  /// ```css
+  /// .foo {
+  ///   color: red;
+  /// }
+  /// ```
+  ///
+  /// will be transformed to:
+  ///
+  /// ```js
+  /// const cssCode = '.foo { color: red; }';
+  /// const farmId = 'foo.module.css';
+  /// const previousStyle = document.querySelector('style[data-farm-id="' + farmId + '"]');
+  /// const style = document.createElement('style');
+  /// style.setAttribute('data-farm-id', farmId);
+  /// style.innerHTML = cssCode;
+  /// if (previousStyle) {
+  ///   previousStyle.remove();
+  /// }
+  /// document.head.appendChild(style);
+  /// ```
+  pub transform_to_script: Option<bool>,
 }
 
 impl Default for CssConfig {
@@ -40,6 +63,7 @@ impl Default for CssConfig {
     Self {
       modules: Some(Default::default()),
       prefixer: Some(Default::default()),
+      transform_to_script: None,
     }
   }
 }

--- a/crates/plugin_css/src/lib.rs
+++ b/crates/plugin_css/src/lib.rs
@@ -482,8 +482,21 @@ impl Plugin for FarmPluginCss {
   }
 
   fn build_end(&self, context: &Arc<CompilationContext>) -> farmfe_core::error::Result<Option<()>> {
-    if !matches!(context.config.mode, farmfe_core::config::Mode::Development)
-      || !matches!(context.config.output.target_env, TargetEnv::Browser)
+    let default_transform_to_script = if context.config.output.target_env.is_browser() {
+      context.config.mode.is_dev()
+    } else {
+      false
+    };
+
+    if !context
+      .config
+      .css
+      .transform_to_script
+      .unwrap_or(default_transform_to_script)
+      || !matches!(
+        context.config.output.target_env,
+        TargetEnv::Browser | TargetEnv::Library
+      )
     {
       return Ok(None);
     }

--- a/crates/plugin_css/src/transform_css_to_script.rs
+++ b/crates/plugin_css/src/transform_css_to_script.rs
@@ -11,7 +11,7 @@ use farmfe_core::{
     },
     ModuleId, ModuleMetaData, ModuleSystem, ModuleType,
   },
-  plugin::{PluginFinalizeModuleHookParam, ResolveKind},
+  plugin::{PluginFinalizeModuleHookParam, PluginProcessModuleHookParam, ResolveKind},
   rayon::prelude::*,
   serialize,
   swc_common::{Globals, Mark},
@@ -147,7 +147,12 @@ pub fn transform_css_to_script_modules(
           .source_map_chain = vec![];
       }
 
-      let css_code = wrapper_style_load(&css_code, module_id.to_string(), &css_deps, src_map);
+      let css_code = wrapper_style_load(
+        &css_code,
+        module_id.id(context.config.mode),
+        &css_deps,
+        src_map,
+      );
       let css_code = Arc::new(css_code);
 
       {
@@ -200,6 +205,21 @@ pub fn transform_css_to_script_modules(
           })));
 
           module.module_type = ModuleType::Js;
+
+          // call process_module hook
+          context
+            .plugin_driver
+            .process_module(
+              &mut PluginProcessModuleHookParam {
+                module_id: &module_id,
+                module_type: &module.module_type.clone(),
+                content: &mut module.content,
+                meta: &mut module.meta,
+                source_map_chain: &mut module.source_map_chain,
+              },
+              context,
+            )
+            .unwrap();
 
           // call finalize_module to update meta
           context

--- a/packages/core/src/types/binding.ts
+++ b/packages/core/src/types/binding.ts
@@ -349,6 +349,14 @@ export interface CssConfig {
   prefixer?: {
     targets?: string[] | string | BrowserTargetsRecord;
   } | null;
+
+  /**
+   * Whether to transform css to script, default is true in development mode and false in production mode.
+   * If set to true, every css module will be transformed to script individually, and the css will be inserted into the head of the document
+   * using document.createElement('style').
+   */
+  transformToScript?: boolean;
+
   /**
    * You SHOULD NOT use this option. It's preserved vite css options for compatibility of vite plugins
    */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `transformToScript` configuration option for CSS modules. When enabled, CSS modules are transformed into scripts that inject styles into the document head. Enabled by default in development mode for browser targets, disabled in production.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->