### PR TITLE
test(utils): add tests for dim, italic and green color functions

### DIFF
--- a/packages/utils/tests/color.spec.ts
+++ b/packages/utils/tests/color.spec.ts
@@ -3,6 +3,9 @@ import {
   bgBlue,
   bold,
   createFormatter,
+  dim,
+  green,
+  italic,
   red,
   reset,
   underline
@@ -51,5 +54,17 @@ describe('color functions', () => {
 
   it('reset should wrap with ansi code', () => {
     expect(reset('abc')).toMatch(/\x1b\[0mabc\x1b\[0m/);
+  });
+
+  it('dim should wrap with ansi code', () => {
+    expect(dim('abc')).toMatch(/\x1b\[2mabc\x1b\[22m/);
+  });
+
+  it('italic should wrap with ansi code', () => {
+    expect(italic('abc')).toMatch(/\x1b\[3mabc\x1b\[23m/);
+  });
+
+  it('green should wrap with ansi code', () => {
+    expect(green('abc')).toMatch(/\x1b\[32mabc\x1b\[39m/);
   });
 });


### PR DESCRIPTION
Add missing test coverage for color utility functions:
- dim: should wrap with ansi code (\x1b[2m...\x1b[22m)
- italic: should wrap with ansi code (\x1b[3m...\x1b[23m)
- green: should wrap with ansi code (\x1b[32m...\x1b[39m)

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for color formatting utilities to verify proper ANSI escape sequence handling across `dim`, `italic`, and `green` color functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->