### PR TITLE
docs: fix incorrect config key from externals to external

### DIFF
--- a/website/docs/tutorials/2-start.md
+++ b/website/docs/tutorials/2-start.md
@@ -291,7 +291,7 @@ and when loading dynamic scripts and css, the dynamic fetched resources url woul
 
 ## Configuring Alias And Externals
 
-Alias and externals are also most useful configurations, we can use `compilation.resolve.alias` and `compilation.externals` in Farm:
+Alias and externals are also most useful configurations, we can use `compilation.resolve.alias` and `compilation.external` in Farm:
 
 ```ts title="farm.config.ts"
 // ...
@@ -303,7 +303,7 @@ export default defineConfig({
         "@/": path.join(process.cwd(), "src"),
       },
     },
-    externals: ["node:fs"],
+    external: ["node:fs"],
   },
   // ...
 });


### PR DESCRIPTION
The documentation incorrectly used `externals` as the config key, but the correct key is `external` (singular).

Closes #2268

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected configuration examples in tutorials to reflect the current API naming conventions for external dependencies configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->