### PR TITLE
docs(visualizer): fix package name in README

### DIFF
--- a/js-plugins/visualizer/README.md
+++ b/js-plugins/visualizer/README.md
@@ -10,29 +10,29 @@
 
 ## Getting Started
 
-To begin, you'll need to install `@farmfe/visualizer`:
+To begin, you'll need to install `@farmfe/js-plugin-visualizer`:
 
 ```console
-npm install @farmfe/visualizer --save-dev
+npm install @farmfe/js-plugin-visualizer --save-dev
 ```
 
 or
 
 ```console
-yarn add -D @farmfe/visualizer
+yarn add -D @farmfe/js-plugin-visualizer
 ```
 
 or
 
 ```console
-pnpm add -D @farmfe/visualizer
+pnpm add -D @farmfe/js-plugin-visualizer
 ```
 
 Configuring the plugin in `farm.config.ts`:
 
 ```ts
 import { defineFarmConfig } from '@farmfe/core/dist/config';
-import visualizer from '@farmfe/visualizer'; //  import the plugin
+import visualizer from '@farmfe/js-plugin-visualizer'; //  import the plugin
 
 export default defineFarmConfig({
   compilation: {


### PR DESCRIPTION
The README incorrectly used `@farmfe/visualizer` as the package name, but the correct package name is `@farmfe/js-plugin-visualizer`.

Closes #2208

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.
-->

**Related issue (if exists):**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated visualizer plugin documentation with the latest package naming information in installation instructions and configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->